### PR TITLE
fix(runtime): harden panic-prone paths across the pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /result
 .idea
 /.direnv
+DEV_GUIDE.md
+.sisyphus/

--- a/src/compile/compiler.rs
+++ b/src/compile/compiler.rs
@@ -280,3 +280,255 @@ fn verify_proj_options(config: &TypsiteConfig<'_>, registry: &KeyRegistry) -> Re
     }
     Ok(errors)
 }
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use crate::compile::compiler::cache::monitor::Monitor;
+    use crate::compile::{
+        init_compile_options, init_proj_options,
+        options::{CompileOptions, ProjOptions},
+    };
+    use crate::config::TypsiteConfig;
+    use std::collections::{HashMap, HashSet};
+    use std::fs;
+    use std::sync::Arc;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn unique_root(label: &str) -> std::path::PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("test timestamp should be available")
+            .as_nanos();
+        std::env::temp_dir().join(format!("typsite-{label}-{unique}"))
+    }
+
+    fn write_test_config(root: &std::path::Path, options: &str) {
+        fs::create_dir_all(root.join("components/footer")).expect("footer dir");
+        fs::create_dir_all(root.join("rewrite")).expect("rewrite dir");
+        fs::create_dir_all(root.join("schemas")).expect("schema dir");
+        fs::create_dir_all(root.join("syntaxes")).expect("syntaxes dir");
+        fs::create_dir_all(root.join("themes")).expect("themes dir");
+        fs::write(root.join("options.toml"), options).expect("options file");
+        fs::write(
+            root.join("components/section.html"),
+            include_str!("../../resources/.typsite/components/section.html"),
+        )
+        .expect("section");
+        fs::write(
+            root.join("components/heading-numbering.html"),
+            "<html><body>{numbering}</body></html>",
+        )
+        .expect("heading numbering");
+        fs::write(
+            root.join("components/footer.html"),
+            "<html><body><footer>{references}{backlinks}</footer></body></html>",
+        )
+        .expect("footer");
+        fs::write(
+            root.join("components/footer/backlinks.html"),
+            "<html><body>{backlinks}</body></html>",
+        )
+        .expect("backlinks");
+        fs::write(
+            root.join("components/footer/references.html"),
+            "<html><body>{references}</body></html>",
+        )
+        .expect("references");
+        fs::write(root.join("components/anchor_def.html"), "<html><body></body></html>")
+            .expect("anchor def");
+        fs::write(root.join("components/anchor_def_svg.html"), "<html><body></body></html>")
+            .expect("anchor def svg");
+        fs::write(root.join("components/anchor_goto.html"), "<html><body></body></html>")
+            .expect("anchor goto");
+        fs::write(root.join("components/anchor_goto_svg.html"), "<html><body></body></html>")
+            .expect("anchor goto svg");
+        fs::write(root.join("components/sidebar.html"), "<html><body>{children}</body></html>")
+            .expect("sidebar");
+        fs::write(root.join("components/sidebar_each.html"), "<html><body>{title}</body></html>")
+            .expect("sidebar each");
+        fs::write(root.join("components/embed.html"), "<html><body>{content}</body></html>")
+            .expect("embed");
+        fs::write(root.join("components/embed_title.html"), "<html><body>{title}</body></html>")
+            .expect("embed title");
+        fs::write(root.join("schemas/main.html"), "<html><body><content></content></body></html>")
+            .expect("schema");
+        fs::write(root.join("schemas/reference.html"), "<html><body><content></content></body></html>")
+            .expect("reference schema");
+    }
+
+    fn init_options(root: &std::path::Path) {
+        let proj = ProjOptions::load(root).expect("project options should load");
+        init_proj_options(proj).expect("project options should initialize");
+        init_compile_options(CompileOptions {
+            watch: false,
+            short_slug: false,
+            pretty_url: true,
+        })
+        .expect("compile options should initialize");
+    }
+
+    pub(crate) fn run_compose_pages_collects_missing_article_as_error() {
+        let root = unique_root("compose-pages-missing-article");
+        let cache = root.join("cache");
+        let typst = root.join("typst");
+        let html = root.join("html");
+        write_test_config(&root, include_str!("../../resources/.typsite/options.toml"));
+        fs::create_dir_all(&cache).expect("cache dir");
+        fs::create_dir_all(&typst).expect("typst dir");
+        fs::create_dir_all(&html).expect("html dir");
+        init_options(&root);
+
+        let config = TypsiteConfig::load(&root, &typst, &html).expect("config should load");
+        let mut registry = KeyRegistry::new();
+        let rev_dep = cache::dep::RevDeps::load(&config, &cache, &HashSet::new(), &mut registry);
+        let changed = HashSet::from([Arc::from("/missing")]);
+        let page_data = page_composer::compose_pages(
+            &config,
+            changed,
+            HashSet::new(),
+            &HashSet::new(),
+            &HashMap::new(),
+            rev_dep,
+            false,
+        )
+        .expect("compose pages should collect the missing article as an error entry");
+
+        assert_eq!(page_data.error_pages.len(), 1);
+        assert!(page_data.error_pages[0].1.contains("should be loaded before composition"));
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    pub(crate) fn run_pass_html_collects_registry_errors_without_unreachable_panics() {
+        let root = unique_root("pass-html-registry-errors");
+        let typst = root.join("typst");
+        let html = root.join("html");
+        write_test_config(&root, include_str!("../../resources/.typsite/options.toml"));
+        fs::create_dir_all(&typst).expect("typst dir");
+        fs::create_dir_all(&html).expect("html dir");
+        init_options(&root);
+
+        let config = TypsiteConfig::load(&root, &typst, &html).expect("config should load");
+        let invalid_html = root.join("outside.html");
+        fs::write(&invalid_html, "<html><body></body></html>").expect("html file");
+        let mut changed_html_paths = vec![invalid_html.clone()];
+        let (articles, errors) = html_pass::pass_html(
+            &config,
+            &cache::article::ArticleCache::new(&root.join("cache")),
+            &mut KeyRegistry::new(),
+            &mut changed_html_paths,
+        );
+
+        assert!(articles.is_empty());
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].0.ends_with("outside.html"));
+        assert!(changed_html_paths.is_empty());
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    pub(crate) fn run_compile_typsts_reports_missing_cache_parent_without_panic() {
+        let root = unique_root("compile-typsts-cache-parent");
+        let cache = root.join("cache");
+        let typst = root.join("typst");
+        let html_cache_root = root.join("html-cache-root");
+        let rendered_html = root.join("rendered-html");
+        write_test_config(&root, include_str!("../../resources/.typsite/options.toml"));
+        fs::create_dir_all(&cache).expect("cache dir");
+        fs::create_dir_all(typst.join("nested")).expect("typst dir");
+        fs::create_dir_all(&rendered_html).expect("rendered html dir");
+        fs::write(typst.join("nested/article.typ"), "= Test").expect("typst file");
+        fs::write(&html_cache_root, "occupied by file").expect("blocking html cache path");
+        init_options(&root);
+
+        let config = TypsiteConfig::load(&root, &typst, &rendered_html).expect("config should load");
+        let mut monitor = Monitor::load(&cache, &root, &typst, &rendered_html, None);
+        let errors = typst_pass::compile_typsts(
+            "typst",
+            &config,
+            &mut monitor,
+            &typst,
+            &root,
+            &html_cache_root,
+            &HashSet::from([typst.join("nested/article.typ")]),
+            HashSet::new(),
+        );
+
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].1.contains("parent") || errors[0].1.contains("Not a directory"));
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    pub(crate) fn run_initialize_reports_packages_path_and_strip_prefix_failures() {
+        let root = unique_root("initialize-packages-path");
+        let cache = root.join("cache");
+        let typst = root.join("typst");
+        let html = root.join("html");
+        let assets = root.join("assets");
+        let packages_dir = root.join("packages");
+        write_test_config(&root, include_str!("../../resources/.typsite/options.toml"));
+        fs::create_dir_all(&cache).expect("cache dir");
+        fs::create_dir_all(&typst).expect("typst dir");
+        fs::create_dir_all(&html).expect("html dir");
+        fs::create_dir_all(&assets).expect("assets dir");
+        fs::create_dir_all(packages_dir.join("broken-package")).expect("packages dir");
+        fs::write(packages_dir.join("broken-package/README.txt"), "missing typst manifest")
+            .expect("package marker file");
+
+        let err = match initializer::initialize(&cache, &typst, &html, &root, &assets, Some(&packages_dir)) {
+            Ok(_) => panic!("file packages path should be reported as an error"),
+            Err(err) => err,
+        };
+        let err = err.to_string();
+
+        assert!(err.contains("Packages installing failed") || err.contains("typst.toml"));
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    pub(crate) fn run_generate_site_outputs_handles_empty_base_url_without_unwrap() {
+        let root = unique_root("generate-site-empty-base-url");
+        write_test_config(&root, include_str!("../../resources/.typsite/options.toml"));
+        init_options(&root);
+
+        let generated = site_output::generate_site_outputs(&HashMap::new())
+            .expect("empty base url should disable outputs without panicking");
+
+        assert!(generated.files.is_empty());
+        assert_eq!(generated.removed.len(), 2);
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn compose_pages_collects_missing_article_as_error() {
+        let _guard = crate::test_lock();
+        run_compose_pages_collects_missing_article_as_error();
+    }
+
+    #[test]
+    fn pass_html_collects_registry_errors_without_unreachable_panics() {
+        let _guard = crate::test_lock();
+        run_pass_html_collects_registry_errors_without_unreachable_panics();
+    }
+
+    #[test]
+    fn compile_typsts_reports_missing_cache_parent_without_panic() {
+        let _guard = crate::test_lock();
+        run_compile_typsts_reports_missing_cache_parent_without_panic();
+    }
+
+    #[test]
+    fn initialize_reports_packages_path_and_strip_prefix_failures() {
+        let _guard = crate::test_lock();
+        run_initialize_reports_packages_path_and_strip_prefix_failures();
+    }
+
+    #[test]
+    fn generate_site_outputs_handles_empty_base_url_without_unwrap() {
+        let _guard = crate::test_lock();
+        run_generate_site_outputs_handles_empty_base_url_without_unwrap();
+    }
+}

--- a/src/compile/compiler/cache/article.rs
+++ b/src/compile/compiler/cache/article.rs
@@ -3,7 +3,7 @@ use crate::compile::error::{TypError, TypResult};
 use crate::compile::registry::{Key, KeyRegistry};
 use crate::config::TypsiteConfig;
 use crate::ir::article::{Article, PureArticle};
-use crate::util::error::{log_err, log_err_or_ok};
+use crate::util::error::log_err_or_ok;
 use crate::util::fs::{remove_file_ignore, remove_file_log_err, write_into_file};
 use crate::walk_glob;
 use anyhow::{anyhow, Context};
@@ -48,7 +48,12 @@ impl<'a> ArticleCache<'a> {
     ) {
         failed.into_iter().for_each(|err| {
             let slug = err.slug.clone();
-            let path = registry.path(&slug).unwrap().to_path_buf();
+            let Some(path) = registry.path(&slug).map(|path| path.to_path_buf()) else {
+                error_articles.insert(slug.clone(), (PathBuf::from(slug.as_ref()), err));
+                registry.remove_slug(&slug);
+                self.cache.remove(&slug);
+                return;
+            };
             registry.remove_slug(&slug);
             self.cache.remove(&slug);
             let cache = self.typ_to_json_path(&path);
@@ -140,24 +145,19 @@ impl<'a> ArticleCache<'a> {
         &mut self,
         slugs: HashMap<Key, (Vec<String>, Vec<String>, Vec<String>)>,
     ) -> anyhow::Result<()> {
-        slugs
-            .into_iter()
-            .map(|(slug, cache)| {
-                let article = self.cache.remove(slug.as_ref()).expect("Article not found");
-                let path = self
-                    .cache_article_path
-                    .join(format!("{}.json", article.path.display()));
-                let pure = PureArticle::from(article, cache);
-                serde_json::to_string::<PureArticle>(&pure)
-                    .context("Failed to serialize pure article")
-                    .map(|json| (path, json))
-            })
-            .filter_map(log_err_or_ok)
-            .collect::<Vec<(PathBuf, String)>>()
-            .into_iter()
-            .par_bridge()
-            .map(|(path, json)| write_into_file(path, &json, "cache article"))
-            .for_each(log_err);
+        for (slug, cache) in slugs {
+            let article = self.cache.remove(slug.as_ref()).ok_or_else(|| {
+                anyhow!("Article cache entry missing while writing cache for {slug}")
+            })?;
+            let path = self
+                .cache_article_path
+                .join(format!("{}.json", article.path.display()));
+            let pure = PureArticle::from(article, cache);
+            let json = serde_json::to_string::<PureArticle>(&pure)
+                .with_context(|| format!("Failed to serialize pure article cache for {slug}"))?;
+            write_into_file(path, &json, "cache article")
+                .with_context(|| format!("Failed to write article cache for {slug}"))?;
+        }
         Ok(())
     }
 

--- a/src/compile/compiler/html_pass.rs
+++ b/src/compile/compiler/html_pass.rs
@@ -36,7 +36,7 @@ pub fn pass_html<'b, 'a: 'b>(
                     .with_context(|| format!("Read file {html_path:?} failed."))
                     .map(|html| {
                         let cache = cache.get(&slug);
-                        pass_pure(config, registry, typst_path, slug.clone(),cache, &html)
+                        pass_pure(config, registry, typst_path, slug.clone(), cache, &html)
                     });
                 (i, result)
             }
@@ -56,7 +56,12 @@ pub fn pass_html<'b, 'a: 'b>(
             registry.remove_slug(slug);
             error_indexes.push((index, format!("{err}")))
         }
-        _ => unreachable!(),
+        Ok(Ok(_)) => {
+            error_indexes.push((
+                index,
+                "Unexpected success entry reached error partition".into(),
+            ));
+        }
     });
     // Remove error indexes
     error_indexes.sort_by_key(|(index, _)| *index);
@@ -70,7 +75,10 @@ pub fn pass_html<'b, 'a: 'b>(
     // Return only successful results
     let articles = success
         .into_iter()
-        .filter_map(|(_, res)| res.ok().unwrap().ok())
+        .filter_map(|(_, res)| match res {
+            Ok(Ok(article)) => Some(article),
+            _ => None,
+        })
         .collect();
     (articles, error_articles)
 }

--- a/src/compile/compiler/initializer.rs
+++ b/src/compile/compiler/initializer.rs
@@ -84,7 +84,9 @@ pub fn initialize<'a>(
     };
     if packages_changed {
         println!("Packages changed");
-        install_packages(packages_path.unwrap()).with_context(|| "Packages installing failed")?;
+        let packages_path =
+            packages_path.context("Packages changed but package root is unavailable")?;
+        install_packages(packages_path).with_context(|| "Packages installing failed")?;
         println!("Packages changed, reloading...");
     }
 
@@ -125,7 +127,10 @@ pub fn initialize<'a>(
         lib_dirs: &HashSet<String>,
     ) {
         paths.retain(|path| {
-            let path = path.strip_prefix(typst_path).unwrap();
+            let path = match path.strip_prefix(typst_path) {
+                std::result::Result::Ok(path) => path,
+                Err(_) => return true,
+            };
             !(lib_files.contains(path.to_string_lossy().as_ref())
                 || lib_dirs.iter().any(|prefix| path.starts_with(prefix)))
         });
@@ -165,6 +170,9 @@ pub fn initialize<'a>(
 
 impl<'a> Input<'a> {
     pub fn unchanged(&self) -> bool {
+        let watch_mode = compile_options()
+            .expect("compile options should be initialized before Input::unchanged checks")
+            .watch;
         self.changed_typst_paths.is_empty()
             && self.deleted_typst_paths.is_empty()
             && self.changed_config_paths.is_empty()
@@ -172,7 +180,8 @@ impl<'a> Input<'a> {
             && self.changed_non_typst.is_empty()
             && self.deleted_non_typst.is_empty()
             // In watch mode, ignore `retry_html_paths` when determining if a file is `unchanged`
-            && ( compile_options().unwrap().watch || (self.retry_html_paths.is_empty() && self.retry_typst_paths.is_empty()) )
+            && (watch_mode
+                || (self.retry_html_paths.is_empty() && self.retry_typst_paths.is_empty()))
     }
 }
 

--- a/src/compile/compiler/output_sync.rs
+++ b/src/compile/compiler/output_sync.rs
@@ -84,13 +84,7 @@ pub fn sync_files_to_output<'a>(output: Output<'a>) {
     remove_pages(typst_path, output_path, deleted_pages);
     write_generated(output_path, generated_files);
     remove_generated(output_path, generated_removed);
-    remove_errors(
-        monitor,
-        error_articles,
-        html_cache_path,
-        typst_path,
-        output_path,
-    );
+    remove_errors(monitor, error_articles, html_cache_path, output_path);
 }
 
 fn write_pages(monitor: &Monitor, typst_path: &Path, output_path: &Path, output: UpdatedPages) {
@@ -98,9 +92,8 @@ fn write_pages(monitor: &Monitor, typst_path: &Path, output_path: &Path, output:
         .into_iter()
         .map(|(typ_path, html)| {
             monitor.remove_retry_hash(&typ_path);
-            let html_path = relative_path(typst_path, &typ_path)
-                .map(|it| it.with_extension("html"))
-                .unwrap();
+            let html_path =
+                relative_path(typst_path, &typ_path).map(|it| it.with_extension("html"))?;
             let output_path = output_path.join(html_path);
             if output_path.exists() {
                 println!("  ∓ {output_path:#?}");
@@ -192,11 +185,16 @@ fn remove_output(parent: &Path, file: &Path, output_path: &Path) -> Result<()> {
     remove_file(&output, "output")?;
     println!("  - {output:#?}");
     // check if the dir is empty, if it is, remove the dir
-    let mut parent = output.parent().unwrap();
-    while parent != output {
+    let Some(mut parent) = output.parent() else {
+        return Ok(());
+    };
+    while parent.starts_with(output_path) && parent != output_path {
         if fs::read_dir(parent)?.next().is_none() {
             fs::remove_dir(parent)?;
-            parent = parent.parent().unwrap();
+            let Some(next_parent) = parent.parent() else {
+                break;
+            };
+            parent = next_parent;
         } else {
             break;
         }
@@ -208,7 +206,6 @@ fn remove_errors(
     monitor: Monitor,
     error_articles: ErrorArticles,
     html_cache_path: &Path,
-    typst_path: &Path,
     output_path: &Path,
 ) {
     error_articles
@@ -221,8 +218,7 @@ fn remove_errors(
                 path
             };
             cache_html_path.set_extension("html");
-            let html_path = relative_path(html_cache_path, &cache_html_path).unwrap();
-            let result = remove_output(typst_path, &html_path, output_path);
+            let result = remove_output(html_cache_path, &cache_html_path, output_path);
             eprintln!("{error}");
             result
         })

--- a/src/compile/compiler/page_composer.rs
+++ b/src/compile/compiler/page_composer.rs
@@ -16,6 +16,10 @@ use std::sync::{Arc, OnceLock};
 
 use super::{analyse_slugs_to_update_and_load, ErrorArticles, PathBufs, UpdatedPages};
 
+fn invariant_err(slug: &Key, message: impl Into<String>) -> crate::compile::error::TypError {
+    crate::compile::error::TypError::new_with(slug.clone(), vec![anyhow!(message.into())])
+}
+
 pub type PageCache = HashMap<Key, (Vec<String>, Vec<String>, Vec<String>)>;
 
 pub struct PageData<'a> {
@@ -73,13 +77,21 @@ pub fn compose_pages<'c, 'b: 'c, 'a: 'b>(
     // update_meta_content_indexes
     slugs_to_update
         .iter()
-        .map(|slug| {
-            let article = global_data.article(slug).unwrap();
-            let meta_rewriter_indexes = global_meta_indexes.remove(article.slug.as_ref()).unwrap();
+        .try_for_each(|slug| -> TypResult<()> {
+            let Some(article) = global_data.article(slug) else {
+                return Ok(());
+            };
+            let mut meta_rewriter_indexes = global_meta_indexes
+                .remove(article.slug.as_ref())
+                .ok_or_else(|| {
+                    invariant_err(
+                        slug,
+                        format!(
+                            "meta index entry for {slug} should be precomputed before composition"
+                        ),
+                    )
+                })?;
             let meta_contents = article.get_meta_contents();
-            (meta_contents, meta_rewriter_indexes)
-        })
-        .map(|(meta_contents, mut meta_rewriter_indexes)| {
             if meta_rewriter_indexes.is_empty() {
                 for meta_key in meta_contents.keys() {
                     meta_rewriter_indexes.insert(meta_key.to_string(), Indexes::All);
@@ -88,9 +100,10 @@ pub fn compose_pages<'c, 'b: 'c, 'a: 'b>(
             for (meta_key, indexes) in meta_rewriter_indexes {
                 meta_contents.pass_content(&meta_key, indexes, &global_data);
             }
-            meta_contents
+            meta_contents.init_parent(&global_data);
+            Ok(())
         })
-        .for_each(|meta_contents| meta_contents.init_parent(&global_data));
+        .map_err(|err| anyhow!(err.to_string()))?;
 
     let empty_pos = vec![];
     let final_cache = slugs_to_update
@@ -102,7 +115,12 @@ pub fn compose_pages<'c, 'b: 'c, 'a: 'b>(
     let (output, failed): (Vec<TypResult<_>>, Vec<TypResult<_>>) = slugs_to_update
         .par_iter()
         .map(|slug| -> TypResult<(&Article, (String, String))> {
-            let article = global_data.article(slug).unwrap(); // Pretty ensure that the article is valid
+            let article = global_data.article(slug).ok_or_else(|| {
+                invariant_err(
+                    slug,
+                    format!("article {slug} should be loaded before composition"),
+                )
+            })?;
             let pending = article.get_pending_or_init(&global_data);
             let (content, full_sidebar, embed_sidebar) = pending.based_on(
                 config,
@@ -120,9 +138,21 @@ pub fn compose_pages<'c, 'b: 'c, 'a: 'b>(
                 embed_sidebar.join("")
             };
 
-            final_cache[slug]
+            final_cache
+                .get(slug)
+                .ok_or_else(|| {
+                    invariant_err(
+                        slug,
+                        format!("page cache slot for {slug} should be preallocated"),
+                    )
+                })?
                 .set((content, full_sidebar, embed_sidebar))
-                .unwrap();
+                .map_err(|_| {
+                    invariant_err(
+                        slug,
+                        format!("page cache slot for {slug} should only be written once"),
+                    )
+                })?;
             let node = &article.get_meta_node();
             if !node.backlinks.is_empty() {
                 // If the article has Backlinks -> it's cited, the citing articles need the reference.
@@ -152,17 +182,30 @@ pub fn compose_pages<'c, 'b: 'c, 'a: 'b>(
             })
         })
         .partition(|res| res.is_ok());
-    let cache: PageCache = final_cache
-        .into_iter()
-        .par_bridge()
-        .map(|(slug, lock)| (slug, lock.into_inner().unwrap()))
-        .collect();
+    let mut cache = PageCache::new();
+    let mut cache_failures = Vec::new();
+    for (slug, lock) in final_cache {
+        match lock.into_inner() {
+            Some(page_cache) => {
+                cache.insert(slug, page_cache);
+            }
+            None if global_data.article(&slug).is_some() => cache_failures.push(invariant_err(
+                &slug,
+                format!("page cache slot for {slug} should be initialized during composition"),
+            )),
+            None => {}
+        }
+    }
     let updated_pages: UpdatedPages = output.into_iter().flatten().collect();
     let error_articles = failed
         .into_iter()
         .filter_map(|it| it.err())
+        .chain(cache_failures)
         .map(|err| {
-            let path = global_data.article(&err.slug).unwrap().path.to_path_buf();
+            let path = global_data
+                .article(&err.slug)
+                .map(|article| article.path.to_path_buf())
+                .unwrap_or_else(|| err.slug.as_ref().into());
             (path, format!("{err}"))
         })
         .collect();
@@ -194,21 +237,24 @@ where
     let mut global_indexes: HashMap<Key, HashSet<UpdatedIndex>> = slugs_to_update
         .iter()
         .map(|slug| {
-            let article = updated_articles.get(slug).unwrap(); // We pretty ensure that the article is valid
-            let changed = changed_typst_paths.contains(article.path.as_ref()); // If the article is updated
-            let indexes = if overall_compile_needed || changed {
-                HashSet::new() // If it's init or updated, we need to update all indexes, which is represented by an empty set
+            let indexes = if let Some(article) = updated_articles.get(slug) {
+                let changed = changed_typst_paths.contains(article.path.as_ref()); // If the article is updated
+                if overall_compile_needed || changed {
+                    HashSet::new() // If it's init or updated, we need to update all indexes, which is represented by an empty set
+                } else {
+                    updated_typst_paths // Changed typst files
+                        .iter()
+                        .chain(changed_config_paths.iter())
+                        .filter_map(
+                            |path| rev_dependency.take_dependency(slug, path),
+                            // Collect all dependencies (with indexes) of the article,
+                            // For each (changed) dependency, collect the indexes of the article
+                        )
+                        .flatten()
+                        .collect::<HashSet<_>>()
+                }
             } else {
-                updated_typst_paths // Changed typst files
-                    .iter()
-                    .chain(changed_config_paths.iter())
-                    .filter_map(
-                        |path| rev_dependency.take_dependency(slug, path),
-                        // Collect all dependencies (with indexes) of the article,
-                        // For each (changed) dependency, collect the indexes of the article
-                    )
-                    .flatten()
-                    .collect::<HashSet<_>>()
+                HashSet::new()
             };
             (slug.clone(), indexes)
         })

--- a/src/compile/compiler/site_output.rs
+++ b/src/compile/compiler/site_output.rs
@@ -30,7 +30,7 @@ pub fn generate_site_outputs(articles: &HashMap<Key, Article<'_>>) -> Result<Gen
     let sitemap_path = normalize_output_path(&site.sitemap_path);
     let base_url = normalize_base_url(&site.base_url);
 
-    if base_url.is_none() {
+    let Some(base_url) = base_url else {
         let mut removed = Vec::new();
         if let Some(path) = rss_path {
             removed.push(path);
@@ -42,9 +42,7 @@ pub fn generate_site_outputs(articles: &HashMap<Key, Article<'_>>) -> Result<Gen
             files: Vec::new(),
             removed,
         });
-    }
-
-    let base_url = base_url.unwrap();
+    };
     let pretty_url = compile_options()?.pretty_url;
     let mut entries = collect_entries(articles, &base_url, pretty_url);
 

--- a/src/compile/compiler/typst_pass.rs
+++ b/src/compile/compiler/typst_pass.rs
@@ -2,7 +2,7 @@ use crate::compile::error::TypError;
 use crate::config::TypsiteConfig;
 use rayon::prelude::*;
 use std::sync::Arc;
-use std::{fs::create_dir_all, path::Path, result::Result::Ok};
+use std::{path::Path, result::Result::Ok};
 
 use crate::util::error::TypsiteError;
 use crate::util::fs::create_all_parent_dir;
@@ -76,11 +76,13 @@ pub fn compile_typsts(
             let mut html_path = typ_path.clone();
             html_path.set_extension("html");
             let cache_output = html_cache_path.join(&html_path);
-            create_dir_all(cache_output.parent().unwrap()).unwrap();
+            let prepare_output = create_all_parent_dir(&cache_output);
             (
                 slug,
                 typ_path.clone(),
-                compile_typst(typst, typst_path, config_path, typ_path, &cache_output),
+                prepare_output.and_then(|_| {
+                    compile_typst(typst, typst_path, config_path, typ_path, &cache_output)
+                }),
             )
         })
         .filter_map(|(slug, path, res)| {

--- a/src/compile/options.rs
+++ b/src/compile/options.rs
@@ -40,7 +40,7 @@ impl ProjOptions {
         Ok(options)
     }
 }
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct CodeFallbackStyle {
     pub dark: String,
     pub light: String,

--- a/src/compile/registry.rs
+++ b/src/compile/registry.rs
@@ -58,7 +58,15 @@ impl KeyRegistry {
         let slug = config.path_to_slug(path)?;
         let slug: Key = self.register_slug(slug);
         let path = if path.starts_with(config.html_path) {
-            path.strip_prefix(config.html_path).unwrap().with_extension("typ")
+            path.strip_prefix(config.html_path)
+                .with_context(|| {
+                    format!(
+                        "Failed to strip html root {} from {}",
+                        config.html_path.display(),
+                        path.display()
+                    )
+                })?
+                .with_extension("typ")
         } else {
             path.to_path_buf()
         };

--- a/src/compile/watch.rs
+++ b/src/compile/watch.rs
@@ -29,7 +29,10 @@ pub async fn watch(compiler: Compiler,host:String, port: u16) -> Result<()> {
     if let Err(e) = server_result {
         return Err(anyhow!("{e}"));
     }
-    let server =  server_result.unwrap();
+    let server = match server_result {
+        Ok(server) => server,
+        Err(err) => return Err(anyhow!(err)),
+    };
     let publish_dir = compiler.output_path().to_path_buf();
 
     let server_task = tokio::task::Builder::new()
@@ -70,7 +73,9 @@ fn server_task(server: Server, publish_dir: PathBuf, mut reload_receiver: Receiv
         if raw_path == "_reload" {
             let refresh = reload_receiver.try_recv().is_ok();
             let response = Response::from_string(if refresh { "1" } else { "0" });
-            request.respond(response).unwrap();
+            if let Err(err) = request.respond(response) {
+                eprintln!("[WARN] Failed to respond to reload request: {err}");
+            }
             continue;
         }
 
@@ -97,7 +102,9 @@ fn server_task(server: Server, publish_dir: PathBuf, mut reload_receiver: Receiv
             Ok(file) => {
                 let response = Response::from_file(file);
                 println!("Request: {raw_path_display} -> {full_path_display}");
-                request.respond(response).unwrap();
+                if let Err(err) = request.respond(response) {
+                    eprintln!("[WARN] Failed to respond with file {full_path_display}: {err}");
+                }
             }
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                 println!("Request: {raw_path_display} -> 404");
@@ -112,11 +119,47 @@ fn server_task(server: Server, publish_dir: PathBuf, mut reload_receiver: Receiv
 }
 
 fn respond_403(r: tiny_http::Request) {
-    r.respond(Response::empty(403)).unwrap();
+    if let Err(err) = r.respond(Response::empty(403)) {
+        eprintln!("[WARN] Failed to respond with 403: {err}");
+    }
 }
 fn respond_404(r: tiny_http::Request) {
-    r.respond(Response::empty(404)).unwrap();
+    if let Err(err) = r.respond(Response::empty(404)) {
+        eprintln!("[WARN] Failed to respond with 404: {err}");
+    }
 }
 fn respond_500(r: tiny_http::Request) {
-    r.respond(Response::empty(500)).unwrap();
+    if let Err(err) = r.respond(Response::empty(500)) {
+        eprintln!("[WARN] Failed to respond with 500: {err}");
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use std::io::Write;
+    use std::net::TcpStream;
+    use std::thread;
+
+    pub(crate) fn run_watch_response_errors_are_logged_not_panicked() {
+        let server = Server::http("127.0.0.1:0").expect("server should bind to a local port");
+        let addr = server.server_addr().to_string();
+        let handle = thread::spawn(move || {
+            let request = server.recv().expect("request should arrive");
+            respond_404(request);
+        });
+
+        let mut stream = TcpStream::connect(&addr).expect("client should connect");
+        stream
+            .write_all(b"GET /missing HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .expect("request should be written");
+        drop(stream);
+
+        handle.join().expect("respond_404 path should not panic");
+    }
+
+    #[test]
+    fn watch_response_errors_are_logged_not_panicked() {
+        run_watch_response_errors_are_logged_not_panicked();
+    }
 }

--- a/src/config/heading_numbering.rs
+++ b/src/config/heading_numbering.rs
@@ -37,3 +37,31 @@ impl HeadingNumberingConfig {
         )
     }
 }
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+
+    pub(crate) fn run_heading_numbering_roman_overflow_is_reported() {
+        let config = HeadingNumberingConfig {
+            path: std::path::PathBuf::from("heading-numbering.html").into(),
+            head: String::new(),
+            body: "{numbering}|{anchor}".to_string(),
+        };
+
+        let rendered = config.get_with_pos_anchor(
+            HeadingNumberingStyle::Roman,
+            None,
+            None,
+            &vec![20],
+            "/article",
+        );
+
+        assert_eq!(rendered, "?|article-21");
+    }
+
+    #[test]
+    fn heading_numbering_roman_overflow_is_reported() {
+        run_heading_numbering_roman_overflow_is_reported();
+    }
+}

--- a/src/config/highlight.rs
+++ b/src/config/highlight.rs
@@ -2,20 +2,18 @@ use crate::config::THEMES_DIR;
 use crate::util::error::log_err_or_ok;
 use crate::util::path::file_stem;
 use crate::walk_glob;
-use anyhow::{Result,Context};
+use anyhow::Context;
 use glob::glob;
 use metadata::{LoadMetadata, RawMetadataEntry};
 use rayon::iter::{ParallelBridge, ParallelIterator};
-use syntect::dumps::from_binary;
 use std::fmt::{Display, Formatter};
 use std::fs;
 use std::path::Path;
 use std::sync::{Arc, OnceLock};
 use std::{collections::BTreeMap, path::PathBuf};
+use syntect::dumps::from_binary;
 use syntect::highlighting::{Theme, ThemeSet};
-use syntect::parsing::{
-    Metadata, SyntaxDefinition, SyntaxReference, SyntaxSet, SyntaxSetBuilder,
-};
+use syntect::parsing::{Metadata, SyntaxDefinition, SyntaxReference, SyntaxSet, SyntaxSetBuilder};
 
 use super::SYNTAXES_DIR;
 
@@ -111,7 +109,11 @@ impl CodeHightlightConfig {
     }
 
     pub fn metadata_paths(&self) -> Vec<Arc<Path>> {
-        self.syntaxes.metadata_paths_by_stem.values().cloned().collect()
+        self.syntaxes
+            .metadata_paths_by_stem
+            .values()
+            .cloned()
+            .collect()
     }
 
     pub fn is_syntax_by_default(&self, token: &str) -> bool {
@@ -120,24 +122,23 @@ impl CodeHightlightConfig {
     fn syntax_set_by_extension(&self) -> &SyntaxSet {
         &self.syntaxes.syntax_set
     }
-
 }
 
 impl Display for CodeHightlightConfig {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "Syntaxes by deffault:")?;
         for syntax in default_syntax_set().syntaxes() {
-            writeln!(f, "    - {}",syntax.name)?;
+            writeln!(f, "    - {}", syntax.name)?;
         }
 
         writeln!(f, "Syntaxes by extension:")?;
         for syntax in self.syntax_set_by_extension().syntaxes() {
-            writeln!(f, "    - {}",syntax.name)?;
+            writeln!(f, "    - {}", syntax.name)?;
         }
 
         writeln!(f, "Themes")?;
         for theme in self.themes.keys() {
-            writeln!(f,"    - {theme}")?;
+            writeln!(f, "    - {theme}")?;
         }
         Ok(())
     }
@@ -182,8 +183,10 @@ impl Syntaxes {
                 syntax_set.add(syntax);
                 let path: Arc<Path> = Arc::from(path);
                 syntax_paths_by_name.insert(name, path.clone());
-                let stem = file_stem(&path).unwrap().to_string();
-                syntax_paths_by_stem.insert(stem, path.clone());
+                let stem = file_stem(&path).expect(
+                    "syntax files matched by *.sublime-syntax should always have a file stem",
+                );
+                syntax_paths_by_stem.insert(stem.to_string(), path.clone());
             });
         let mut syntax_set = syntax_set.build();
         let mut raw_metadata = LoadMetadata::default();
@@ -208,8 +211,10 @@ impl Syntaxes {
             .for_each(|(path, metadata)| {
                 raw_metadata.add_raw(metadata);
                 let path: Arc<Path> = Arc::from(path);
-                let stem = file_stem(&path).unwrap().to_string();
-                metadata_paths_by_stem.insert(stem, path);
+                let stem = file_stem(&path).expect(
+                    "metadata files matched by *.tmPreferences should always have a file stem",
+                );
+                metadata_paths_by_stem.insert(stem.to_string(), path);
             });
         syntax_set.set_metadata(Metadata::from(raw_metadata));
 

--- a/src/config/highlight/metadata.rs
+++ b/src/config/highlight/metadata.rs
@@ -1,8 +1,8 @@
 use std::{collections::BTreeMap, fs::File, io::BufReader, path::PathBuf};
 
+use super::settings::*;
 use serde::{Deserialize, Serialize};
 use syntect::parsing::{Metadata, MetadataSet};
-use super::settings::*;
 
 type Dict = serde_json::Map<String, Settings>;
 
@@ -10,8 +10,6 @@ type Dict = serde_json::Map<String, Settings>;
 ///
 /// [`ScopeSelectors`]: ../../highlighting/struct.ScopeSelectors.html
 type SelectorString = String;
-
-
 
 /// From `syntect`
 /// A type that can be deserialized from a `.tmPreferences` file.
@@ -32,7 +30,13 @@ impl RawMetadataEntry {
         // we stash the path because we use it to determine parse order
         // when generating the final metadata object; to_string_lossy
         // is adequate for this purpose.
-        contents.as_object_mut().and_then(|obj| obj.insert("path".into(), path.to_string_lossy().into()));
+        let object = contents.as_object_mut().ok_or_else(|| {
+            anyhow::anyhow!(
+                "tmPreferences {} did not parse into an object",
+                path.display()
+            )
+        })?;
+        object.insert("path".into(), path.to_string_lossy().into());
         Ok(serde_json::from_value(contents)?)
     }
 }
@@ -42,7 +46,6 @@ impl RawMetadataEntry {
 pub(crate) struct LoadMetadata {
     loaded: Vec<RawMetadataEntry>,
 }
-
 
 // all of these are optional, but we don't want to deserialize if
 // we don't have at least _one_ of them present
@@ -63,13 +66,20 @@ impl From<LoadMetadata> for Metadata {
 
         let mut scoped_metadata: BTreeMap<SelectorString, Dict> = BTreeMap::new();
 
-        for RawMetadataEntry { scope, settings, path } in loaded {
-            let scoped_settings = scoped_metadata.entry(scope.clone())
-                .or_insert_with(|| {
-                    let mut d = Dict::new();
-                    d.insert("source_file_path".to_string(), path.to_string_lossy().into());
-                    d
-                });
+        for RawMetadataEntry {
+            scope,
+            settings,
+            path,
+        } in loaded
+        {
+            let scoped_settings = scoped_metadata.entry(scope.clone()).or_insert_with(|| {
+                let mut d = Dict::new();
+                d.insert(
+                    "source_file_path".to_string(),
+                    path.to_string_lossy().into(),
+                );
+                d
+            });
 
             for (key, value) in settings {
                 if !KEYS_WE_USE.contains(&key.as_str()) {
@@ -77,39 +87,49 @@ impl From<LoadMetadata> for Metadata {
                 }
 
                 if key.as_str() == "shellVariables" {
-                    append_vars(scoped_settings, value, &scope);
+                    if let Err(err) = append_vars(scoped_settings, value, &scope) {
+                        eprintln!(
+                            "failed to merge tmPreferences shellVariables for scope {scope} from {}: {err}",
+                            path.display()
+                        );
+                    }
                 } else {
                     scoped_settings.insert(key, value);
                 }
             }
         }
 
-        let scoped_metadata = scoped_metadata.into_iter()
-            .flat_map(|r|
-                 MetadataSet::from_raw(r)
-                     .map_err(|e| eprintln!("{e}")))
+        let scoped_metadata = scoped_metadata
+            .into_iter()
+            .flat_map(|r| MetadataSet::from_raw(r).map_err(|e| eprintln!("{e}")))
             .collect();
         Metadata { scoped_metadata }
     }
 }
 
-fn append_vars(obj: &mut Dict, vars: Settings, scope: &str) {
+fn append_vars(obj: &mut Dict, vars: Settings, scope: &str) -> anyhow::Result<()> {
     #[derive(Deserialize)]
-    struct KeyPair { name: String, value: Settings }
+    struct KeyPair {
+        name: String,
+        value: Settings,
+    }
     #[derive(Deserialize)]
     struct ShellVars(Vec<KeyPair>);
 
-    let shell_vars = obj.entry(String::from("shellVariables"))
-        .or_insert_with(|| Dict::new().into())
-        .as_object_mut().unwrap();
-    match serde_json::from_value::<ShellVars>(vars) {
-	Ok(vars) => {
-	    for KeyPair { name, value } in vars.0 {
-		shell_vars.insert(name, value);
-	    }
-	}
-	Err(e) => eprintln!("malformed shell variables for scope {scope}, {e:}"),
+    let vars = serde_json::from_value::<ShellVars>(vars)
+        .map_err(|err| anyhow::anyhow!("malformed shell variables for scope {scope}: {err}"))?;
+    let shell_vars = obj
+        .entry(String::from("shellVariables"))
+        .or_insert_with(|| Dict::new().into());
+    let shell_vars = shell_vars.as_object_mut().ok_or_else(|| {
+        anyhow::anyhow!(
+            "malformed shellVariables container for scope {scope}: expected object while merging tmPreferences metadata"
+        )
+    })?;
+    for KeyPair { name, value } in vars.0 {
+        shell_vars.insert(name, value);
     }
+    Ok(())
 }
 
 impl LoadMetadata {
@@ -123,5 +143,4 @@ impl LoadMetadata {
     pub fn add_raw(&mut self, raw: RawMetadataEntry) {
         self.loaded.push(raw);
     }
-
 }

--- a/src/config/highlight/settings.rs
+++ b/src/config/highlight/settings.rs
@@ -1,4 +1,3 @@
-
 /// Code based on <https://github.com/defuz/sublimate/blob/master/src/core/settings.rs>
 /// released under the MIT license by @defuz
 use plist::Error as PlistError;

--- a/src/config/rewrite.rs
+++ b/src/config/rewrite.rs
@@ -1,15 +1,15 @@
-use crate::config::{RULES_DIR, TypsiteConfig};
+use crate::config::{TypsiteConfig, RULES_DIR};
 use crate::ir::article::data::GlobalData;
 use crate::ir::article::dep::Source;
 use crate::pass::pure::PurePass;
 use crate::pass::rewrite::*;
 use crate::util::error::log_err_or_ok;
+use crate::util::html::parse_first_tag;
 use crate::util::html::Attributes;
 use crate::util::html::HtmlWithTail;
-use crate::util::html::parse_first_tag;
 use crate::util::path::file_stem;
 use crate::walk_glob;
-use anyhow::{Context, anyhow};
+use anyhow::{anyhow, Context};
 use glob::glob;
 use html5gum::{Token, Tokenizer};
 use rayon::prelude::*;
@@ -89,11 +89,8 @@ impl<'b, 'a: 'b> TagRewriteRule {
             t => Err(anyhow!("Unexpected token {:?} in rewrite tag", t)),
         })?;
 
-        if tag.is_none() || pass.is_none() {
-            return Err(anyhow!("Tag or pass is empty in {}", path.display()));
-        }
-        let tag = tag.unwrap();
-        let pass = pass.unwrap();
+        let tag = tag.with_context(|| format!("Missing rewrite tag name in {}", path.display()))?;
+        let pass = pass.with_context(|| format!("Missing rewrite pass in {}", path.display()))?;
 
         let (head, body, tail) = HtmlWithTail::load_by_tokenizer(tokenizer, "{body}")
             .map(|HtmlWithTail { head, body, tail }| (head, body, tail))?;

--- a/src/config/section.rs
+++ b/src/config/section.rs
@@ -16,24 +16,35 @@ impl SectionConfig {
     pub fn load(config: &Path) -> anyhow::Result<Self> {
         let path = Arc::from(config.join(SECTION_PATH));
         let HtmlWithElem { head, body } = HtmlWithElem::load(&path)?;
-        if body
+        let title_count = body.iter().filter(|&it| it == &SectionElem::Title).count();
+        let content_count = body
             .iter()
-            .filter(|&it| it == &SectionElem::Content || it == &SectionElem::Title)
-            .count()
-            != 2
-        {
+            .filter(|&it| it == &SectionElem::Content)
+            .count();
+        if title_count != 1 || content_count != 1 {
             return Err(anyhow::anyhow!(
-                "Invalid heading config, must contain exactly one title and one content tag"
+                "Invalid heading config in {}: expected exactly one {{title}} placeholder and one {{content}} placeholder",
+                path.display()
             ));
         }
         let title_index = body
             .iter()
             .position(|it| it == &SectionElem::Title)
-            .unwrap();
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Invalid heading config in {}: missing {{title}} placeholder",
+                    path.display()
+                )
+            })?;
         let content_index = body
             .iter()
             .position(|it| it == &SectionElem::Content)
-            .unwrap();
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Invalid heading config in {}: missing {{content}} placeholder",
+                    path.display()
+                )
+            })?;
         Ok(SectionConfig {
             path,
             head,
@@ -51,5 +62,45 @@ impl SectionConfig {
     }
     pub fn after_content(&self) -> &[SectionElem] {
         &self.body[self.content_index + 1..]
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use std::{
+        fs,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    pub(crate) fn run_config_loader_reports_missing_section_placeholders() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("test timestamp should be available")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("typsite-section-config-{unique}"));
+        let components = root.join("components");
+        fs::create_dir_all(&components).expect("test components directory should be created");
+        fs::write(
+            components.join("section.html"),
+            "<html><body><div>{title}</div></body></html>",
+        )
+        .expect("test section config should be written");
+
+        let err = match SectionConfig::load(&root) {
+            Ok(_) => panic!("missing content placeholder should be reported"),
+            Err(err) => err,
+        };
+        let err = err.to_string();
+
+        assert!(err.contains("section.html"));
+        assert!(err.contains("{content}"));
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn config_loader_reports_missing_section_placeholders() {
+        run_config_loader_reports_missing_section_placeholders();
     }
 }

--- a/src/ir/article.rs
+++ b/src/ir/article.rs
@@ -68,9 +68,13 @@ impl<'c, 'b: 'c, 'a: 'b> Article<'a> {
         config: &'a TypsiteConfig,
         registry: &KeyRegistry,
     ) -> TypResult<Article<'a>> {
-        let self_slug = registry.know(pure.slug, "Article", "").unwrap();
-        let path = registry.path(self_slug.as_ref()).unwrap();
+        let self_slug = registry
+            .slug(pure.slug.as_str())
+            .unwrap_or_else(|| Arc::from(pure.slug.as_str()));
         let mut err = TypError::new(self_slug.clone());
+        let path = err.ok(registry
+            .path(self_slug.as_ref())
+            .with_context(|| format!("Article path not found for {}", self_slug)));
         let schema = config.schemas.get(&pure.schema);
         let schema = err.ok(schema);
         let metadata = Metadata::from(self_slug.clone(), pure.metadata, config, registry);
@@ -101,11 +105,37 @@ impl<'c, 'b: 'c, 'a: 'b> Article<'a> {
         if err.has_error() {
             return Err(err);
         }
-        let metadata = metadata.unwrap();
-        let schema = schema.unwrap();
-        let body = body.unwrap();
+        let path = path.ok_or_else(|| {
+            TypError::new_with(
+                self_slug.clone(),
+                vec![anyhow::anyhow!("Article path missing after validation")],
+            )
+        })?;
+        let metadata = metadata.ok_or_else(|| {
+            TypError::new_with(
+                self_slug.clone(),
+                vec![anyhow::anyhow!("Metadata missing after validation")],
+            )
+        })?;
+        let schema = schema.ok_or_else(|| {
+            TypError::new_with(
+                self_slug.clone(),
+                vec![anyhow::anyhow!("Schema missing after validation")],
+            )
+        })?;
+        let body = body.ok_or_else(|| {
+            TypError::new_with(
+                self_slug.clone(),
+                vec![anyhow::anyhow!("Body missing after validation")],
+            )
+        })?;
         let embeds = embeds.into_iter().flatten().collect();
-        let dependency = dependency.unwrap();
+        let dependency = dependency.ok_or_else(|| {
+            TypError::new_with(
+                self_slug.clone(),
+                vec![anyhow::anyhow!("Dependency missing after validation")],
+            )
+        })?;
         let used_rules = used_rules.into_iter().flatten().collect();
         let article = Article {
             slug: self_slug,
@@ -251,6 +281,197 @@ impl<'c, 'b: 'c, 'a: 'b> Article<'a> {
 
     pub fn get_anchors(&'b self) -> &'b Vec<AnchorData> {
         &self.anchors
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use crate::compile::{
+        init_compile_options, init_proj_options,
+        options::{CompileOptions, ProjOptions},
+    };
+    use crate::config::TypsiteConfig;
+    use crate::ir::article::body::Body;
+    use crate::ir::article::dep::Dependency;
+    use crate::ir::metadata::options::MetaOptions;
+    use crate::ir::metadata::{Metadata, PureMetadata};
+    use std::fs;
+    use std::sync::Arc;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn write_test_config(root: &std::path::Path) {
+        fs::create_dir_all(root.join("components/footer")).expect("footer dir");
+        fs::create_dir_all(root.join("rewrite")).expect("rewrite dir");
+        fs::create_dir_all(root.join("schemas")).expect("schema dir");
+        fs::create_dir_all(root.join("syntaxes")).expect("syntaxes dir");
+        fs::create_dir_all(root.join("themes")).expect("themes dir");
+
+        fs::write(
+            root.join("options.toml"),
+            include_str!("../../resources/.typsite/options.toml"),
+        )
+        .expect("options file");
+        fs::write(
+            root.join("components/section.html"),
+            include_str!("../../resources/.typsite/components/section.html"),
+        )
+        .expect("section");
+        fs::write(
+            root.join("components/heading-numbering.html"),
+            "<html><body>{numbering}</body></html>",
+        )
+        .expect("heading numbering");
+        fs::write(
+            root.join("components/footer.html"),
+            "<html><body><footer>{references}{backlinks}</footer></body></html>",
+        )
+        .expect("footer");
+        fs::write(
+            root.join("components/footer/backlinks.html"),
+            "<html><body>{backlinks}</body></html>",
+        )
+        .expect("backlinks");
+        fs::write(
+            root.join("components/footer/references.html"),
+            "<html><body>{references}</body></html>",
+        )
+        .expect("references");
+        fs::write(
+            root.join("components/anchor_def.html"),
+            "<html><body></body></html>",
+        )
+        .expect("anchor def");
+        fs::write(
+            root.join("components/anchor_def_svg.html"),
+            "<html><body></body></html>",
+        )
+        .expect("anchor def svg");
+        fs::write(
+            root.join("components/anchor_goto.html"),
+            "<html><body></body></html>",
+        )
+        .expect("anchor goto");
+        fs::write(
+            root.join("components/anchor_goto_svg.html"),
+            "<html><body></body></html>",
+        )
+        .expect("anchor goto svg");
+        fs::write(
+            root.join("components/sidebar.html"),
+            "<html><body>{children}</body></html>",
+        )
+        .expect("sidebar");
+        fs::write(
+            root.join("components/sidebar_each.html"),
+            "<html><body>{title}</body></html>",
+        )
+        .expect("sidebar each");
+        fs::write(
+            root.join("components/embed.html"),
+            "<html><body>{content}</body></html>",
+        )
+        .expect("embed");
+        fs::write(
+            root.join("components/embed_title.html"),
+            "<html><body>{title}</body></html>",
+        )
+        .expect("embed title");
+        fs::write(
+            root.join("schemas/reference.html"),
+            "<html><body><content></content></body></html>",
+        )
+        .expect("reference schema");
+    }
+
+    pub(crate) fn run_article_from_collects_registry_and_schema_errors() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("test timestamp should be available")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("typsite-article-from-{unique}"));
+        let typst = root.join("typst");
+        let html = root.join("html");
+        write_test_config(&root);
+        fs::create_dir_all(&typst).expect("typst dir");
+        fs::create_dir_all(&html).expect("html dir");
+
+        let config = TypsiteConfig::load(&root, &typst, &html).expect("config should load");
+        let proj = ProjOptions::load(&root).expect("project options should load");
+        init_proj_options(proj).expect("project options should initialize");
+        init_compile_options(CompileOptions {
+            watch: false,
+            short_slug: false,
+            pretty_url: true,
+        })
+        .expect("compile options should initialize");
+
+        let pure = PureArticle {
+            path: std::path::PathBuf::from("missing.typ"),
+            slug: "/missing".to_string(),
+            schema: "missing-schema".to_string(),
+            metadata: PureMetadata::from(Metadata {
+                contents: crate::ir::metadata::content::MetaContents::new(
+                    Arc::from("/missing"),
+                    HashMap::new(),
+                    false,
+                ),
+                options: MetaOptions {
+                    heading_numbering_style:
+                        crate::ir::article::sidebar::HeadingNumberingStyle::Bullet,
+                    sidebar_type: crate::ir::article::sidebar::SidebarType::All,
+                },
+                node: crate::ir::metadata::graph::MetaNode {
+                    slug: Arc::from("/missing"),
+                    parent: Some(Arc::from("/missing-parent")),
+                    parents: HashSet::new(),
+                    backlinks: HashSet::new(),
+                    references: HashSet::new(),
+                    children: HashSet::new(),
+                },
+            }),
+            head: Vec::new(),
+            body: body::PureBody::from(Body::new(Vec::new(), Vec::new(), HashMap::new())),
+            full_sidebar: Sidebar::new(
+                Vec::new(),
+                HashSet::new(),
+                HashSet::new(),
+                HashMap::new(),
+                HashMap::new(),
+            ),
+            embed_sidebar: Sidebar::new(
+                Vec::new(),
+                HashSet::new(),
+                HashSet::new(),
+                HashMap::new(),
+                HashMap::new(),
+            ),
+            embeds: Vec::new(),
+            dependency: crate::ir::article::dep::PureDependency::from(Dependency::new(
+                HashMap::new(),
+            )),
+            used_rules: HashSet::new(),
+            anchors: Vec::new(),
+        };
+        let registry = KeyRegistry::new();
+
+        let err = match Article::from(pure, &config, &registry) {
+            Ok(_) => panic!("missing registry path and schema should be aggregated"),
+            Err(err) => err,
+        };
+        let err = err.to_string();
+
+        assert!(err.contains("Article path not found for /missing"));
+        assert!(err.contains("No schema named missing-schema"));
+        assert!(err.contains("Parent not found: /missing-parent in /missing"));
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn article_from_collects_registry_and_schema_errors() {
+        let _guard = crate::test_lock();
+        run_article_from_collects_registry_and_schema_errors();
     }
 }
 

--- a/src/ir/article/data.rs
+++ b/src/ir/article/data.rs
@@ -6,12 +6,13 @@ use crate::compile::registry::Key;
 use crate::compile::watch::WATCH_AUTO_RELOAD_SCRIPT;
 use crate::config::schema::{BACKLINK_KEY, REFERENCE_KEY};
 use crate::config::TypsiteConfig;
+use crate::ir::article::sidebar::HeadingNumberingStyle;
 use crate::ir::metadata::Metadata;
 use crate::ir::pending::Pending;
 use crate::pass::{pass_embed, pass_rewriter_body, pass_schema};
 use crate::util::html::{OutputHead, OutputHtml};
 use std::collections::{HashMap, HashSet};
-use std::sync::OnceLock;
+use std::sync::{Mutex, OnceLock};
 
 use super::dep::Indexes;
 use super::Article;
@@ -22,6 +23,8 @@ pub struct GlobalData<'a, 'b, 'c> {
     pendings: HashMap<Key, OnceLock<Pending<'c>>>,
     global_body_rewrite_indexes: HashMap<Key, Indexes>,
     global_body_embed_indexes: HashMap<Key, Indexes>,
+    runtime_errors: Mutex<HashMap<Key, TypError>>,
+    invalid_pending: OnceLock<Pending<'c>>,
 }
 impl<'c, 'b: 'c, 'a: 'b> GlobalData<'a, 'b, 'c> {
     pub fn new(
@@ -37,8 +40,54 @@ impl<'c, 'b: 'c, 'a: 'b> GlobalData<'a, 'b, 'c> {
             pendings,
             global_body_rewrite_indexes,
             global_body_embed_indexes,
+            runtime_errors: Mutex::new(HashMap::new()),
+            invalid_pending: OnceLock::new(),
         }
     }
+
+    fn record_runtime_error(&self, slug: Key, err: anyhow::Error) {
+        let mut errors = self
+            .runtime_errors
+            .lock()
+            .expect("global runtime error cache should not be poisoned");
+        errors
+            .entry(slug.clone())
+            .or_insert_with(|| TypError::new(slug))
+            .add(err);
+    }
+
+    fn invalid_pending(&'c self) -> &'c Pending<'c> {
+        self.invalid_pending.get_or_init(|| {
+            let raw = Box::leak(Box::new((Vec::new(), Vec::new(), Vec::new())));
+            let anchors = Box::leak(Box::new(Vec::new()));
+            Pending::new(
+                raw,
+                HeadingNumberingStyle::Bullet,
+                Vec::new(),
+                crate::ir::pending::SidebarData::new(
+                    crate::ir::pending::SidebarIndexesData::new(HashSet::new()),
+                    Vec::new(),
+                    Vec::new(),
+                ),
+                crate::ir::pending::SidebarData::new(
+                    crate::ir::pending::SidebarIndexesData::new(HashSet::new()),
+                    Vec::new(),
+                    Vec::new(),
+                ),
+                Vec::new(),
+                anchors,
+            )
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn take_runtime_error(&self, id: &str) -> Option<TypError> {
+        self.runtime_errors
+            .lock()
+            .expect("global runtime error cache should not be poisoned")
+            .remove(id)
+    }
+
     pub fn article(&'c self, id: &str) -> Option<&'b Article<'a>> {
         self.articles.get(id)
     }
@@ -52,14 +101,21 @@ impl<'c, 'b: 'c, 'a: 'b> GlobalData<'a, 'b, 'c> {
         &'c self,
         article: &'b Article<'a>,
     ) -> (Vec<String>, Vec<String>, Vec<String>) {
-        let rewriter_indexes = self
-            .global_body_rewrite_indexes
-            .get(article.slug.as_ref())
-            .unwrap();
         let metadata = &article.metadata;
         let mut body = article.body.clone();
         let mut full_sidebar = article.full_sidebar.cache(metadata);
         let embed_sidebar = article.embed_sidebar.cache(metadata);
+        let Some(rewriter_indexes) = self.global_body_rewrite_indexes.get(article.slug.as_ref())
+        else {
+            self.record_runtime_error(
+                article.slug.clone(),
+                anyhow!(
+                    "Missing global body rewrite indexes for loaded article {}",
+                    article.slug
+                ),
+            );
+            return (body.content, full_sidebar, embed_sidebar);
+        };
         pass_rewriter_body(
             article.slug.clone(),
             &mut body.content,
@@ -72,25 +128,51 @@ impl<'c, 'b: 'c, 'a: 'b> GlobalData<'a, 'b, 'c> {
     }
 
     pub(super) fn get_pending_or_init(&'c self, article: &'b Article<'a>) -> &'c Pending<'c> {
-        self.pendings
-            .get(article.slug.as_ref())
-            .map(|pending| {
-                pending.get_or_init(|| {
-                    let embed_indexes = self
-                        .global_body_embed_indexes
-                        .get(article.slug.as_ref())
-                        .unwrap();
-                    let content = article.get_content_or_init(self);
-                    pass_embed(
-                        article.slug.clone(),
-                        content,
-                        &article.embeds,
-                        embed_indexes,
-                        self,
-                    )
-                })
-            })
-            .unwrap()
+        let Some(pending) = self.pendings.get(article.slug.as_ref()) else {
+            self.record_runtime_error(
+                article.slug.clone(),
+                anyhow!("Missing pending cache for loaded article {}", article.slug),
+            );
+            return self.invalid_pending();
+        };
+
+        pending.get_or_init(|| {
+            let Some(embed_indexes) = self.global_body_embed_indexes.get(article.slug.as_ref())
+            else {
+                self.record_runtime_error(
+                    article.slug.clone(),
+                    anyhow!(
+                        "Missing global body embed indexes for loaded article {}",
+                        article.slug
+                    ),
+                );
+                return Pending::new(
+                    Box::leak(Box::new((Vec::new(), Vec::new(), Vec::new()))),
+                    article.get_meta_options().heading_numbering_style,
+                    Vec::new(),
+                    crate::ir::pending::SidebarData::new(
+                        crate::ir::pending::SidebarIndexesData::new(HashSet::new()),
+                        Vec::new(),
+                        Vec::new(),
+                    ),
+                    crate::ir::pending::SidebarData::new(
+                        crate::ir::pending::SidebarIndexesData::new(HashSet::new()),
+                        Vec::new(),
+                        Vec::new(),
+                    ),
+                    Vec::new(),
+                    Box::leak(Box::new(Vec::new())),
+                );
+            };
+            let content = article.get_content_or_init(self);
+            pass_embed(
+                article.slug.clone(),
+                content,
+                &article.embeds,
+                embed_indexes,
+                self,
+            )
+        })
     }
     pub fn schema_html(
         &'c self,
@@ -172,8 +254,9 @@ impl<'c, 'b: 'c, 'a: 'b> GlobalData<'a, 'b, 'c> {
         {
             let mut heads = HashSet::new();
             for rule_id in rules.iter() {
-                let rule = self.config.rules.get(rule_id).unwrap();
-                heads.insert(&rule.head);
+                if let Some(rule) = self.config.rules.get(rule_id) {
+                    heads.insert(&rule.head);
+                }
             }
             for rule_head in heads {
                 head.push(rule_head.as_str());
@@ -209,7 +292,10 @@ impl<'c, 'b: 'c, 'a: 'b> GlobalData<'a, 'b, 'c> {
                 .filter_map(|slug| self.article(slug))
                 .for_each(|article| self.init_component_head(article, &mut head));
 
-            if compile_options().unwrap().watch {
+            if compile_options()
+                .map(|options| options.watch)
+                .unwrap_or(false)
+            {
                 head.push(WATCH_AUTO_RELOAD_SCRIPT);
             }
 
@@ -218,5 +304,212 @@ impl<'c, 'b: 'c, 'a: 'b> GlobalData<'a, 'b, 'c> {
 
             head
         })
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use crate::compile::registry::{Key, SlugPath};
+    use crate::config::TypsiteConfig;
+    use crate::ir::article::body::Body;
+    use crate::ir::article::dep::Dependency;
+    use crate::ir::article::sidebar::{HeadingNumberingStyle, Sidebar, SidebarType};
+    use crate::ir::article::Article;
+    use crate::ir::metadata::content::{MetaContent, MetaContents, TITLE_KEY};
+    use crate::ir::metadata::graph::MetaNode;
+    use crate::ir::metadata::options::MetaOptions;
+    use crate::ir::metadata::Metadata;
+    use crate::ir::pending::AnchorData;
+    use std::collections::{HashMap, HashSet};
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn unique_root(label: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("test timestamp should be available")
+            .as_nanos();
+        std::env::temp_dir().join(format!("typsite-{label}-{unique}"))
+    }
+
+    fn write_test_config(root: &Path) {
+        fs::create_dir_all(root.join("components/footer")).expect("footer dir");
+        fs::create_dir_all(root.join("rewrite")).expect("rewrite dir");
+        fs::create_dir_all(root.join("schemas")).expect("schema dir");
+        fs::create_dir_all(root.join("syntaxes")).expect("syntaxes dir");
+        fs::create_dir_all(root.join("themes")).expect("themes dir");
+
+        fs::write(
+            root.join("options.toml"),
+            include_str!("../../../resources/.typsite/options.toml"),
+        )
+        .expect("options file");
+        fs::write(
+            root.join("components/section.html"),
+            include_str!("../../../resources/.typsite/components/section.html"),
+        )
+        .expect("section");
+        fs::write(
+            root.join("components/heading-numbering.html"),
+            "<html><body>{numbering}</body></html>",
+        )
+        .expect("heading numbering");
+        fs::write(
+            root.join("components/footer.html"),
+            "<html><body><footer>{references}{backlinks}</footer></body></html>",
+        )
+        .expect("footer");
+        fs::write(
+            root.join("components/footer/backlinks.html"),
+            "<html><body>{backlinks}</body></html>",
+        )
+        .expect("backlinks");
+        fs::write(
+            root.join("components/footer/references.html"),
+            "<html><body>{references}</body></html>",
+        )
+        .expect("references");
+        fs::write(
+            root.join("components/anchor_def.html"),
+            "<html><body></body></html>",
+        )
+        .expect("anchor def");
+        fs::write(
+            root.join("components/anchor_def_svg.html"),
+            "<html><body></body></html>",
+        )
+        .expect("anchor def svg");
+        fs::write(
+            root.join("components/anchor_goto.html"),
+            "<html><body></body></html>",
+        )
+        .expect("anchor goto");
+        fs::write(
+            root.join("components/anchor_goto_svg.html"),
+            "<html><body></body></html>",
+        )
+        .expect("anchor goto svg");
+        fs::write(
+            root.join("components/sidebar.html"),
+            "<html><body>{children}</body></html>",
+        )
+        .expect("sidebar");
+        fs::write(
+            root.join("components/sidebar_each.html"),
+            "<html><body>{title}</body></html>",
+        )
+        .expect("sidebar each");
+        fs::write(
+            root.join("components/embed.html"),
+            "<html><body>{content}</body></html>",
+        )
+        .expect("embed");
+        fs::write(
+            root.join("components/embed_title.html"),
+            "<html><body>{title}</body></html>",
+        )
+        .expect("embed title");
+        fs::write(
+            root.join("schemas/main.html"),
+            "<html><body><content></content></body></html>",
+        )
+        .expect("main schema");
+        fs::write(
+            root.join("schemas/reference.html"),
+            "<html><body><content></content></body></html>",
+        )
+        .expect("reference schema");
+    }
+
+    fn article_with_title<'a>(config: &'a TypsiteConfig<'a>, slug: &str) -> Article<'a> {
+        let slug = Key::from(slug);
+        let mut contents = HashMap::new();
+        contents.insert(
+            TITLE_KEY.to_string(),
+            MetaContent::new(vec!["Regression Article".to_string()], Vec::new()),
+        );
+        let metadata = Metadata {
+            contents: MetaContents::new(slug.clone(), contents, false),
+            options: MetaOptions {
+                heading_numbering_style: HeadingNumberingStyle::Bullet,
+                sidebar_type: SidebarType::All,
+            },
+            node: MetaNode {
+                slug: slug.clone(),
+                parent: None,
+                parents: HashSet::new(),
+                backlinks: HashSet::new(),
+                references: HashSet::new(),
+                children: HashSet::new(),
+            },
+        };
+
+        Article::new(
+            slug,
+            SlugPath::from(PathBuf::from("article.typ")),
+            metadata,
+            config.schemas.get("main").expect("main schema should load"),
+            Vec::new(),
+            Body::new(Vec::new(), Vec::new(), HashMap::new()),
+            Sidebar::new(
+                Vec::new(),
+                HashSet::new(),
+                HashSet::new(),
+                HashMap::new(),
+                HashMap::new(),
+            ),
+            Sidebar::new(
+                Vec::new(),
+                HashSet::new(),
+                HashSet::new(),
+                HashMap::new(),
+                HashMap::new(),
+            ),
+            Vec::new(),
+            Dependency::new(HashMap::new()),
+            HashSet::new(),
+            Vec::<AnchorData>::new(),
+        )
+    }
+
+    pub(crate) fn run_global_data_reports_missing_rewrite_indexes() {
+        let root = unique_root("global-data-missing-rewrite-indexes");
+        let typst = root.join("typst");
+        let html = root.join("html");
+        write_test_config(&root);
+        fs::create_dir_all(&typst).expect("typst dir");
+        fs::create_dir_all(&html).expect("html dir");
+
+        let config = TypsiteConfig::load(&root, &typst, &html).expect("config should load");
+        let slug = Key::from("/article");
+        let articles = HashMap::from([(slug.clone(), article_with_title(&config, "/article"))]);
+        let global_data = GlobalData::new(
+            &config,
+            &articles,
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+        );
+        let article = global_data
+            .article("/article")
+            .expect("article should exist in test global data");
+
+        let content = article.get_content_or_init(&global_data);
+        let error = global_data
+            .take_runtime_error("/article")
+            .expect("missing rewrite indexes should be recorded");
+
+        assert!(content.0.is_empty());
+        assert!(format!("{error}").contains("Missing global body rewrite indexes"));
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn global_data_reports_missing_rewrite_indexes() {
+        let _guard = crate::test_lock();
+        run_global_data_reports_missing_rewrite_indexes();
     }
 }

--- a/src/ir/article/sidebar.rs
+++ b/src/ir/article/sidebar.rs
@@ -39,10 +39,23 @@ impl Sidebar {
     }
 
     pub fn cache(&self, metadata: &Metadata) -> Vec<String> {
-        let title = metadata.contents.get(TITLE_KEY).unwrap();
         let mut contents = self.contents.clone();
+        let Some(title) = metadata.contents.get(TITLE_KEY) else {
+            let message = format!(
+                "[ERROR] Missing `{TITLE_KEY}` metadata required for sidebar title rendering"
+            );
+            eprintln!("{message}");
+            for &title_index in &self.title_indexes {
+                if let Some(slot) = contents.get_mut(title_index) {
+                    *slot = message.clone();
+                }
+            }
+            return contents;
+        };
         for &title_index in &self.title_indexes {
-            contents[title_index] = title.to_string();
+            if let Some(slot) = contents.get_mut(title_index) {
+                *slot = title.to_string();
+            }
         }
         contents
     }
@@ -114,7 +127,7 @@ impl HeadingNumberingStyle {
                 .join("."),
             Self::Roman => pos
                 .iter()
-                .map(|it| ROMANS[*it])
+                .map(|it| ROMANS.get(*it).copied().unwrap_or("?"))
                 .collect::<Vec<&str>>()
                 .join("."),
             Self::Alphabet => pos

--- a/src/ir/metadata/content.rs
+++ b/src/ir/metadata/content.rs
@@ -78,7 +78,7 @@ impl<'b, 'a: 'b> MetaContents<'a> {
         let content = self.contents.get(key).map(|c| c.get());
         content.or_else(|| {
             proj_options()
-                .unwrap()
+                .expect("project options should be initialized before reading metadata defaults")
                 .default_metadata
                 .content
                 .default
@@ -98,12 +98,14 @@ impl<'b, 'a: 'b> MetaContents<'a> {
                 .iter()
                 .map(|(k, v)| (format!("{{{k}}}"), v.get().to_string()))
                 .collect::<HashMap<_, _>>();
-            let compile_options = compile_options().unwrap();
+            let compile_options = compile_options()
+                .expect("compile options should be initialized before metadata replacements");
+            let (short_slug, pretty_url) = (compile_options.short_slug, compile_options.pretty_url);
             // Short slug
-            let slug_display = if compile_options.short_slug {
+            let slug_display = if short_slug {
                 self.slug
-                    .split('/')
-                    .next_back()
+                    .rsplit('/')
+                    .find(|segment| !segment.is_empty())
                     .unwrap_or(self.slug.as_ref())
             } else {
                 self.slug.as_ref()
@@ -118,7 +120,7 @@ impl<'b, 'a: 'b> MetaContents<'a> {
                 slug_display.to_string(),
             );
 
-            let slug = if !compile_options.pretty_url {
+            let slug = if !pretty_url {
                 format!("{}.html", self.slug)
             } else {
                 self.slug.to_string()
@@ -126,15 +128,18 @@ impl<'b, 'a: 'b> MetaContents<'a> {
 
             map.insert(SLUG_REPLACEMENT.to_string(), slug.to_string());
 
-            map.insert(SLUG_ANCHOR_REPLACEMENT.to_string(), slug[1..].to_string());
+            let slug_anchor = slug
+                .strip_prefix('/')
+                .expect("metadata slug anchors should only be built from normalized slugs with a leading '/'");
+            map.insert(SLUG_ANCHOR_REPLACEMENT.to_string(), slug_anchor.to_string());
 
-            let parent = self.parent.get().cloned().unwrap_or(false);
+            let parent = *self.parent.get_or_init(|| false);
             map.insert(HAS_PARENT_REPLACEMENT.to_string(), parent.to_string());
             map.insert(HAS_PARENT_REPLACEMENT_.to_string(), parent.to_string());
 
             // Add default meta contents
             proj_options()
-                .unwrap()
+                .expect("project options should be initialized before metadata replacements")
                 .default_metadata
                 .content
                 .default
@@ -179,58 +184,46 @@ impl<'b, 'a: 'b> MetaContents<'a> {
     }
 
     pub fn init_parent<'c>(&self, global_data: &'c GlobalData<'a, 'b, 'c>) {
-        let default_parent_slug = proj_options().ok().and_then(|options| {
-            options
-                .default_metadata
-                .graph
-                .default_parent_slug(global_data.config, |slug| {
-                    global_data.article(&slug).map(|it| it.slug.clone())
-                })
-        });
+        let default_parent_slug = proj_options()
+            .expect("project options should be initialized before metadata parent replacements")
+            .default_metadata
+            .graph
+            .default_parent_slug(global_data.config, |slug| {
+                global_data.article(&slug).map(|it| it.slug.clone())
+            });
 
-        let self_metadata = global_data.metadata(self.slug.as_ref()).unwrap();
+        let self_metadata = global_data.metadata(self.slug.as_ref()).expect(
+            "metadata parent replacements should only initialize for slugs present in GlobalData",
+        );
 
-        let parent = self.parent.get_or_init(|| {
-            self_metadata.node.parent.is_some()
-                || default_parent_slug
-                    .as_ref()
-                    .map(|default| default.as_ref() != self.slug.as_ref())
-                    .unwrap_or(false)
+        let resolved_parent_slug = self_metadata.node.parent.clone().or_else(|| {
+            default_parent_slug
+                .clone()
+                .filter(|default| default.as_ref() != self.slug.as_ref())
         });
+        let parent = self.parent.get_or_init(|| resolved_parent_slug.is_some());
         if !parent {
             return;
         }
         self.parent_replacement.get_or_init(|| {
-            self_metadata
-                .node
-                .parent
+            let parent = resolved_parent_slug
                 .clone()
-                .or_else(|| {
-                    if self.parent.get().cloned().unwrap_or(false) {
-                        default_parent_slug
-                    } else {
-                        None
-                    }
+                .expect("metadata parent replacements should resolve a concrete parent slug when `has-parent` is true");
+
+            let parent_metadata = global_data
+                .metadata(parent.as_ref())
+                .expect("metadata parent replacements should only reference parent slugs present in GlobalData");
+            parent_metadata.contents.init_parent(global_data);
+            parent_metadata
+                .contents
+                .init_replacement()
+                .iter()
+                .map(|(k, v)| {
+                    let key = &k[0..k.len() - 1];
+                    let key = format!("{key}@parent}}");
+                    (key, v.to_string())
                 })
-                .as_ref()
-                .and_then(|parent| {
-                    global_data
-                        .metadata(parent.as_ref())
-                        .map(|parent_metadata| {
-                            parent_metadata.contents.init_parent(global_data);
-                            parent_metadata
-                                .contents
-                                .init_replacement()
-                                .iter()
-                                .map(|(k, v)| {
-                                    let key = &k[0..k.len() - 1];
-                                    let key = format!("{key}@parent}}");
-                                    (key, v.to_string())
-                                })
-                                .collect::<HashMap<_, _>>()
-                        })
-                })
-                .unwrap_or_default()
+                .collect::<HashMap<_, _>>()
         });
     }
 
@@ -392,11 +385,27 @@ impl<'ce> Deserialize<'ce> for PureMetaContent {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
+    use crate::compile::{
+        init_compile_options, init_proj_options,
+        options::{CompileOptions, ProjOptions},
+    };
+    use crate::config::TypsiteConfig;
+    use crate::ir::article::body::Body;
+    use crate::ir::article::data::GlobalData;
+    use crate::ir::article::dep::{Dependency, Indexes};
+    use crate::ir::article::{sidebar::Sidebar, Article};
     use crate::ir::metadata::content::PureMetaContent;
+    use crate::ir::metadata::graph::MetaNode;
+    use crate::ir::metadata::options::MetaOptions;
+    use crate::ir::metadata::Metadata;
     use crate::ir::rewriter::{PureRewriter, RewriterType};
     use std::collections::HashMap;
+    use std::collections::HashSet;
+    use std::fs;
+    use std::sync::{Arc, OnceLock};
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
     fn cont_serialize_and_de() {
@@ -437,5 +446,202 @@ mod tests {
         let json = serde_json::to_string(&content).unwrap();
         let metadata_de = serde_json::from_str(&json).unwrap();
         assert_eq!(content, metadata_de)
+    }
+
+    fn write_test_config(root: &std::path::Path, options: &str) {
+        fs::create_dir_all(root.join("components/footer")).expect("footer dir");
+        fs::create_dir_all(root.join("rewrite")).expect("rewrite dir");
+        fs::create_dir_all(root.join("schemas")).expect("schema dir");
+        fs::create_dir_all(root.join("syntaxes")).expect("syntaxes dir");
+        fs::create_dir_all(root.join("themes")).expect("themes dir");
+        fs::write(root.join("options.toml"), options).expect("options file");
+        fs::write(
+            root.join("components/section.html"),
+            include_str!("../../../resources/.typsite/components/section.html"),
+        )
+        .expect("section");
+        fs::write(
+            root.join("components/heading-numbering.html"),
+            "<html><body>{numbering}</body></html>",
+        )
+        .expect("heading numbering");
+        fs::write(
+            root.join("components/footer.html"),
+            "<html><body><footer>{references}{backlinks}</footer></body></html>",
+        )
+        .expect("footer");
+        fs::write(
+            root.join("components/footer/backlinks.html"),
+            "<html><body>{backlinks}</body></html>",
+        )
+        .expect("backlinks");
+        fs::write(
+            root.join("components/footer/references.html"),
+            "<html><body>{references}</body></html>",
+        )
+        .expect("references");
+        fs::write(
+            root.join("components/anchor_def.html"),
+            "<html><body></body></html>",
+        )
+        .expect("anchor def");
+        fs::write(
+            root.join("components/anchor_def_svg.html"),
+            "<html><body></body></html>",
+        )
+        .expect("anchor def svg");
+        fs::write(
+            root.join("components/anchor_goto.html"),
+            "<html><body></body></html>",
+        )
+        .expect("anchor goto");
+        fs::write(
+            root.join("components/anchor_goto_svg.html"),
+            "<html><body></body></html>",
+        )
+        .expect("anchor goto svg");
+        fs::write(
+            root.join("components/sidebar.html"),
+            "<html><body>{children}</body></html>",
+        )
+        .expect("sidebar");
+        fs::write(
+            root.join("components/sidebar_each.html"),
+            "<html><body>{title}</body></html>",
+        )
+        .expect("sidebar each");
+        fs::write(
+            root.join("components/embed.html"),
+            "<html><body>{content}</body></html>",
+        )
+        .expect("embed");
+        fs::write(
+            root.join("components/embed_title.html"),
+            "<html><body>{title}</body></html>",
+        )
+        .expect("embed title");
+        fs::write(
+            root.join("schemas/main.html"),
+            "<html><body><content></content></body></html>",
+        )
+        .expect("schema");
+    }
+
+    pub(crate) fn run_meta_contents_init_replacement_handles_root_slug_and_parent_defaults() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("test timestamp should be available")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("typsite-meta-contents-{unique}"));
+        let typst = root.join("typst");
+        let html = root.join("html");
+        write_test_config(
+            &root,
+            r#"
+[default_metadata.content]
+title = "Fallback Title"
+
+[default_metadata.options]
+heading_numbering = "Bullet"
+sidebar_type = "All"
+
+[default_metadata.graph]
+parent = "/"
+
+[typst_lib]
+paths = []
+
+[code_fallback_style]
+dark = "dark"
+light = "light"
+"#,
+        );
+        fs::create_dir_all(&typst).expect("typst dir");
+        fs::create_dir_all(&html).expect("html dir");
+
+        let config = TypsiteConfig::load(&root, &typst, &html).expect("config should load");
+        let proj = ProjOptions::load(&root).expect("project options should load");
+        init_proj_options(proj).expect("project options should initialize");
+        init_compile_options(CompileOptions {
+            watch: false,
+            short_slug: true,
+            pretty_url: true,
+        })
+        .expect("compile options should initialize");
+
+        let slug: crate::compile::registry::Key = Arc::from("/");
+        let metadata = Metadata {
+            contents: MetaContents::new(slug.clone(), HashMap::new(), false),
+            options: MetaOptions {
+                heading_numbering_style: crate::ir::article::sidebar::HeadingNumberingStyle::Bullet,
+                sidebar_type: crate::ir::article::sidebar::SidebarType::All,
+            },
+            node: MetaNode {
+                slug: slug.clone(),
+                parent: None,
+                parents: HashSet::new(),
+                backlinks: HashSet::new(),
+                references: HashSet::new(),
+                children: HashSet::new(),
+            },
+        };
+        let article = Article::new(
+            slug.clone(),
+            Arc::from(std::path::Path::new("index.typ")),
+            metadata,
+            config.schemas.get("main").expect("schema should exist"),
+            Vec::new(),
+            Body::new(Vec::new(), Vec::new(), HashMap::new()),
+            Sidebar::new(
+                Vec::new(),
+                HashSet::new(),
+                HashSet::new(),
+                HashMap::new(),
+                HashMap::new(),
+            ),
+            Sidebar::new(
+                Vec::new(),
+                HashSet::new(),
+                HashSet::new(),
+                HashMap::new(),
+                HashMap::new(),
+            ),
+            Vec::new(),
+            Dependency::new(HashMap::new()),
+            HashSet::new(),
+            Vec::new(),
+        );
+        let articles = HashMap::from([(slug.clone(), article)]);
+        let global_data = GlobalData::new(
+            &config,
+            &articles,
+            HashMap::<_, OnceLock<_>>::new(),
+            HashMap::from([(slug.clone(), Indexes::All)]),
+            HashMap::from([(slug.clone(), Indexes::All)]),
+        );
+        let contents = &articles
+            .get(&slug)
+            .expect("article should exist")
+            .get_metadata()
+            .contents;
+
+        contents.init_parent(&global_data);
+        let replaced = contents.inline_with(
+            "slug={slug-display}; anchor={slug@anchor}; parent={has-parent}; title={title}; page={page-title}",
+            &[],
+        );
+
+        assert_eq!(
+            replaced,
+            "slug=/; anchor=; parent=false; title=Fallback Title; page=Fallback Title"
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn meta_contents_init_replacement_handles_root_slug_and_parent_defaults() {
+        let _guard = crate::test_lock();
+        run_meta_contents_init_replacement_handles_root_slug_and_parent_defaults();
     }
 }

--- a/src/ir/pending.rs
+++ b/src/ir/pending.rs
@@ -12,6 +12,21 @@ use std::collections::HashSet;
 
 use super::embed::EmbedVariables;
 
+fn write_slot(slots: &mut [String], index: usize, value: String, target: &str) {
+    if let Some(slot) = slots.get_mut(index) {
+        *slot = value;
+        return;
+    }
+
+    let message = format!(
+        "[ERROR] Missing {target} write target at index {index} while applying pending data"
+    );
+    eprintln!("{message}");
+    if let Some(slot) = slots.last_mut() {
+        *slot = message;
+    }
+}
+
 pub struct BodyNumberingData {
     pos: Pos,
     anchor: String,
@@ -41,7 +56,7 @@ impl BodyNumberingData {
             &self.pos,
             self.anchor.as_str(),
         );
-        body[self.body_index] = numbering.clone();
+        write_slot(body, self.body_index, numbering, "body numbering");
     }
 }
 
@@ -112,7 +127,7 @@ impl SidebarNumberingData {
             self.anchor.as_str(),
         );
         for &index in &self.sidebar_indexes {
-            sidebar[index] = numbering.clone();
+            write_slot(sidebar, index, numbering.clone(), "sidebar numbering");
         }
     }
 }
@@ -133,7 +148,7 @@ impl SidebarAnchorData {
         let pos_anchor = pos_base_on(base_anchor, Some(&self.pos));
         let anchor = pos_slug(&pos_anchor, &self.anchor);
         for &index in &self.sidebar_indexes {
-            sidebar[index] = anchor.clone();
+            write_slot(sidebar, index, anchor.clone(), "sidebar anchor");
         }
     }
 }
@@ -150,7 +165,7 @@ impl SidebarIndexesData {
             _ => "block",
         };
         for &index in &self.sidebar_indexes {
-            sidebar[index] = if_show.to_string();
+            write_slot(sidebar, index, if_show.to_string(), "sidebar visibility");
         }
     }
 }
@@ -213,7 +228,9 @@ impl<'c> EmbedData<'c> {
         sidebar_type: SidebarType,
     ) {
         let pos = &self.pos;
-        let metadata = global_data.metadata(self.slug.as_ref()).unwrap();
+        let Some(metadata) = global_data.metadata(self.slug.as_ref()) else {
+            return;
+        };
         let numbering = config.heading_numbering.get_with_pos_anchor(
             parent_style,
             base_anchor,
@@ -250,14 +267,24 @@ impl<'c> EmbedData<'c> {
                 SectionType::None => {}
                 _ => {
                     for &title_index in &self.full_sidebar_title_indexes {
-                        full_sidebar_vec[title_index] = self.title.clone();
+                        write_slot(
+                            &mut full_sidebar_vec,
+                            title_index,
+                            self.title.clone(),
+                            "full sidebar title",
+                        );
                     }
                     embed_article_sidebar = full_sidebar_vec.join("");
                 }
             }
         } else {
             for &title_index in &self.embed_sidebar_title_indexes {
-                embed_sidebar_vec[title_index] = self.title.clone();
+                write_slot(
+                    &mut embed_sidebar_vec,
+                    title_index,
+                    self.title.clone(),
+                    "embed sidebar title",
+                );
             }
             embed_article_sidebar = embed_sidebar_vec.join("")
         };
@@ -282,14 +309,19 @@ impl<'c> EmbedData<'c> {
         let embed_body = embed_article_body.join("");
         let embed_body = ac_replace(&embed_body, &replacements);
         let embed_body = metadata.inline(&embed_body);
-        body[self.body_index] = embed_body;
+        write_slot(body, self.body_index, embed_body, "embed body");
         let indexes = if sidebar_type == SidebarType::All {
             &self.full_sidebar_indexes
         } else {
             &self.embed_sidebar_indexes
         };
         for &index in indexes {
-            sidebar[index] = embed_article_sidebar.clone();
+            write_slot(
+                sidebar,
+                index,
+                embed_article_sidebar.clone(),
+                "embed sidebar",
+            );
         }
     }
 }
@@ -321,7 +353,7 @@ impl AnchorData {
     fn based_on(&self, config: &AnchorConfig, base: Option<&Pos>, body: &mut [String]) {
         let text = config.get(&self.kind, base, &self.anchor);
         for &index in &self.body_indexes {
-            body[index] = text.clone();
+            write_slot(body, index, text.clone(), "anchor body");
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,3 +13,151 @@ pub(crate) mod util;
 async fn main() -> anyhow::Result<()> {
     cli().await
 }
+
+#[cfg(test)]
+fn test_lock() -> std::sync::MutexGuard<'static, ()> {
+    use std::sync::{Mutex, OnceLock};
+
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(())).lock().expect("test lock should not be poisoned")
+}
+
+#[cfg(test)]
+#[test]
+fn article_from_collects_registry_and_schema_errors() {
+    let _guard = test_lock();
+    crate::ir::article::tests::run_article_from_collects_registry_and_schema_errors();
+}
+
+#[cfg(test)]
+#[test]
+fn config_loader_reports_missing_section_placeholders() {
+    let _guard = test_lock();
+    crate::config::section::tests::run_config_loader_reports_missing_section_placeholders();
+}
+
+#[cfg(test)]
+#[test]
+fn schema_pass_reports_missing_metadata_tag_attr() {
+    let _guard = test_lock();
+    crate::pass::schema::tests::run_schema_pass_reports_missing_metadata_tag_attr();
+}
+
+#[cfg(test)]
+#[test]
+fn meta_contents_init_replacement_handles_root_slug_and_parent_defaults() {
+    let _guard = test_lock();
+    crate::ir::metadata::content::tests::run_meta_contents_init_replacement_handles_root_slug_and_parent_defaults();
+}
+
+#[cfg(test)]
+#[test]
+fn ac_replacement_handles_empty_patterns_without_unwrap() {
+    let _guard = test_lock();
+    crate::util::str::tests::run_ac_replacement_handles_empty_patterns_without_unwrap();
+}
+
+#[cfg(test)]
+#[test]
+fn sidebar_builder_reports_invalid_parent_section() {
+    let _guard = test_lock();
+    crate::pass::pure::tests::run_sidebar_builder_reports_invalid_parent_section();
+}
+
+#[cfg(test)]
+#[test]
+fn pos_slug_rejects_missing_leading_slash() {
+    let _guard = test_lock();
+    crate::util::tests::run_pos_slug_rejects_missing_leading_slash();
+}
+
+#[cfg(test)]
+#[test]
+fn pure_pass_reports_missing_sidebar_title_slot() {
+    let _guard = test_lock();
+    crate::pass::pure::tests::run_pure_pass_reports_missing_sidebar_title_slot();
+}
+
+#[cfg(test)]
+#[test]
+fn metadata_builder_reports_unbalanced_metacontent_state() {
+    let _guard = test_lock();
+    crate::pass::pure::tests::run_metadata_builder_reports_unbalanced_metacontent_state();
+}
+
+#[cfg(test)]
+#[test]
+fn rewrite_pass_reports_missing_required_attr() {
+    let _guard = test_lock();
+    crate::pass::rewrite::tests::run_rewrite_pass_reports_missing_required_attr();
+}
+
+#[cfg(test)]
+#[test]
+fn compose_pages_collects_missing_article_as_error() {
+    let _guard = test_lock();
+    crate::compile::compiler::tests::run_compose_pages_collects_missing_article_as_error();
+}
+
+#[cfg(test)]
+#[test]
+fn pass_html_collects_registry_errors_without_unreachable_panics() {
+    let _guard = test_lock();
+    crate::compile::compiler::tests::run_pass_html_collects_registry_errors_without_unreachable_panics();
+}
+
+#[cfg(test)]
+#[test]
+fn compile_typsts_reports_missing_cache_parent_without_panic() {
+    let _guard = test_lock();
+    crate::compile::compiler::tests::run_compile_typsts_reports_missing_cache_parent_without_panic();
+}
+
+#[cfg(test)]
+#[test]
+fn watch_response_errors_are_logged_not_panicked() {
+    let _guard = test_lock();
+    crate::compile::watch::tests::run_watch_response_errors_are_logged_not_panicked();
+}
+
+#[cfg(test)]
+#[test]
+fn initialize_reports_packages_path_and_strip_prefix_failures() {
+    let _guard = test_lock();
+    crate::compile::compiler::tests::run_initialize_reports_packages_path_and_strip_prefix_failures();
+}
+
+#[cfg(test)]
+#[test]
+fn generate_site_outputs_handles_empty_base_url_without_unwrap() {
+    let _guard = test_lock();
+    crate::compile::compiler::tests::run_generate_site_outputs_handles_empty_base_url_without_unwrap();
+}
+
+#[cfg(test)]
+#[test]
+fn tokenizer_parses_svg_anchor_without_strip_prefix_panic() {
+    let _guard = test_lock();
+    crate::pass::tokenizer::tests::run_tokenizer_parses_svg_anchor_without_strip_prefix_panic();
+}
+
+#[cfg(test)]
+#[test]
+fn pending_pass_skips_missing_embed_article_without_panicking() {
+    let _guard = test_lock();
+    crate::pass::tests::run_pending_pass_skips_missing_embed_article_without_panicking();
+}
+
+#[cfg(test)]
+#[test]
+fn global_data_reports_missing_rewrite_indexes() {
+    let _guard = test_lock();
+    crate::ir::article::data::tests::run_global_data_reports_missing_rewrite_indexes();
+}
+
+#[cfg(test)]
+#[test]
+fn heading_numbering_roman_overflow_is_reported() {
+    let _guard = test_lock();
+    crate::config::heading_numbering::tests::run_heading_numbering_roman_overflow_is_reported();
+}

--- a/src/pass/mod.rs
+++ b/src/pass/mod.rs
@@ -1,10 +1,10 @@
 use crate::compile::error::TypResult;
 use crate::compile::registry::{Key, KeyRegistry, SlugPath};
-use crate::config::TypsiteConfig;
 use crate::config::schema::Schema;
-use crate::ir::article::Article;
+use crate::config::TypsiteConfig;
 use crate::ir::article::data::GlobalData;
 use crate::ir::article::dep::Indexes;
+use crate::ir::article::Article;
 use crate::ir::embed::Embed;
 use crate::ir::pending::Pending;
 use crate::ir::rewriter::{BodyRewriter, MetaRewriter};
@@ -18,7 +18,7 @@ use html5gum::Tokenizer as HtmlTokenizer;
 mod pending;
 pub mod pure;
 pub mod rewrite;
-mod schema;
+pub(crate) mod schema;
 pub mod tokenizer;
 
 pub fn pass_pure<'b, 'a: 'b, 'k, 'c>(
@@ -73,4 +73,11 @@ pub fn pass_schema<'c, 'b: 'c, 'a: 'b>(
     global_data: &'c GlobalData<'a, 'b, 'c>,
 ) -> TypResult<OutputHtml<'a>> {
     SchemaPass::new(config, schema, article, content, sidebar, global_data).run()
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    pub(crate) fn run_pending_pass_skips_missing_embed_article_without_panicking() {
+        super::pending::tests::run_pending_pass_skips_missing_embed_article_without_panicking();
+    }
 }

--- a/src/pass/pending.rs
+++ b/src/pass/pending.rs
@@ -28,7 +28,7 @@ impl<'c, 'b: 'c, 'a: 'b> PendingPass<'a, 'b, 'c> {
         match indexes {
             Indexes::All => self.run_self(embeds.iter().collect(), content),
             Indexes::Some(indexes) => {
-                let embeds: Vec<&Embed> = indexes.iter().map(|&i| &embeds[i]).collect();
+                let embeds: Vec<&Embed> = indexes.iter().filter_map(|&i| embeds.get(i)).collect();
                 self.run_self(embeds, content)
             }
         }
@@ -102,7 +102,9 @@ impl<'c, 'b: 'c, 'a: 'b> PendingPass<'a, 'b, 'c> {
             );
             return None;
         }
-        let child = child.unwrap();
+        let Some(child) = child else {
+            return None;
+        };
         let child_metadata = child.get_metadata();
         let child_pending = child.get_pending_or_init(self.global_data);
         let section_type = embed.section_type;
@@ -136,7 +138,10 @@ impl<'c, 'b: 'c, 'a: 'b> PendingPass<'a, 'b, 'c> {
         embeds: Vec<&Embed>,
         content: &'c (Vec<String>, Vec<String>, Vec<String>),
     ) -> Pending<'c> {
-        let article = self.global_data.article(self.slug.as_ref()).unwrap();
+        let article = self
+            .global_data
+            .article(self.slug.as_ref())
+            .expect("pending pass should only run for registered articles");
         let style = article.get_meta_options().heading_numbering_style;
         let body_numberings = self.emit_body_numberings(&article.get_body().numberings);
         let full_sidebar = article.get_full_sidebar();
@@ -154,5 +159,218 @@ impl<'c, 'b: 'c, 'a: 'b> PendingPass<'a, 'b, 'c> {
             embeds,
             anchors,
         )
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use crate::compile::registry::{Key, SlugPath};
+    use crate::config::TypsiteConfig;
+    use crate::ir::article::body::Body;
+    use crate::ir::article::dep::{Dependency, Indexes};
+    use crate::ir::article::sidebar::{HeadingNumberingStyle, Sidebar, SidebarPos, SidebarType};
+    use crate::ir::article::Article;
+    use crate::ir::embed::SectionType;
+    use crate::ir::metadata::content::{MetaContent, MetaContents, TITLE_KEY};
+    use crate::ir::metadata::graph::MetaNode;
+    use crate::ir::metadata::options::MetaOptions;
+    use crate::ir::metadata::Metadata;
+    use crate::ir::pending::AnchorData;
+    use std::collections::{HashMap, HashSet};
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn unique_root(label: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("test timestamp should be available")
+            .as_nanos();
+        std::env::temp_dir().join(format!("typsite-{label}-{unique}"))
+    }
+
+    fn write_test_config(root: &Path) {
+        fs::create_dir_all(root.join("components/footer")).expect("footer dir");
+        fs::create_dir_all(root.join("rewrite")).expect("rewrite dir");
+        fs::create_dir_all(root.join("schemas")).expect("schema dir");
+        fs::create_dir_all(root.join("syntaxes")).expect("syntaxes dir");
+        fs::create_dir_all(root.join("themes")).expect("themes dir");
+
+        fs::write(
+            root.join("options.toml"),
+            include_str!("../../resources/.typsite/options.toml"),
+        )
+        .expect("options file");
+        fs::write(
+            root.join("components/section.html"),
+            include_str!("../../resources/.typsite/components/section.html"),
+        )
+        .expect("section");
+        fs::write(
+            root.join("components/heading-numbering.html"),
+            "<html><body>{numbering}</body></html>",
+        )
+        .expect("heading numbering");
+        fs::write(
+            root.join("components/footer.html"),
+            "<html><body><footer>{references}{backlinks}</footer></body></html>",
+        )
+        .expect("footer");
+        fs::write(
+            root.join("components/footer/backlinks.html"),
+            "<html><body>{backlinks}</body></html>",
+        )
+        .expect("backlinks");
+        fs::write(
+            root.join("components/footer/references.html"),
+            "<html><body>{references}</body></html>",
+        )
+        .expect("references");
+        fs::write(
+            root.join("components/anchor_def.html"),
+            "<html><body></body></html>",
+        )
+        .expect("anchor def");
+        fs::write(
+            root.join("components/anchor_def_svg.html"),
+            "<html><body></body></html>",
+        )
+        .expect("anchor def svg");
+        fs::write(
+            root.join("components/anchor_goto.html"),
+            "<html><body></body></html>",
+        )
+        .expect("anchor goto");
+        fs::write(
+            root.join("components/anchor_goto_svg.html"),
+            "<html><body></body></html>",
+        )
+        .expect("anchor goto svg");
+        fs::write(
+            root.join("components/sidebar.html"),
+            "<html><body>{children}</body></html>",
+        )
+        .expect("sidebar");
+        fs::write(
+            root.join("components/sidebar_each.html"),
+            "<html><body>{title}</body></html>",
+        )
+        .expect("sidebar each");
+        fs::write(
+            root.join("components/embed.html"),
+            "<html><body>{content}</body></html>",
+        )
+        .expect("embed");
+        fs::write(
+            root.join("components/embed_title.html"),
+            "<html><body>{title}</body></html>",
+        )
+        .expect("embed title");
+        fs::write(
+            root.join("schemas/main.html"),
+            "<html><body><content></content></body></html>",
+        )
+        .expect("main schema");
+        fs::write(
+            root.join("schemas/reference.html"),
+            "<html><body><content></content></body></html>",
+        )
+        .expect("reference schema");
+    }
+
+    fn article_with_title<'a>(config: &'a TypsiteConfig<'a>, slug: &str) -> Article<'a> {
+        let slug = Key::from(slug);
+        let mut contents = HashMap::new();
+        contents.insert(
+            TITLE_KEY.to_string(),
+            MetaContent::new(vec!["Regression Article".to_string()], Vec::new()),
+        );
+        let metadata = Metadata {
+            contents: MetaContents::new(slug.clone(), contents, false),
+            options: MetaOptions {
+                heading_numbering_style: HeadingNumberingStyle::Bullet,
+                sidebar_type: SidebarType::All,
+            },
+            node: MetaNode {
+                slug: slug.clone(),
+                parent: None,
+                parents: HashSet::new(),
+                backlinks: HashSet::new(),
+                references: HashSet::new(),
+                children: HashSet::new(),
+            },
+        };
+
+        Article::new(
+            slug,
+            SlugPath::from(PathBuf::from("article.typ")),
+            metadata,
+            config.schemas.get("main").expect("main schema should load"),
+            Vec::new(),
+            Body::new(Vec::new(), Vec::new(), HashMap::new()),
+            Sidebar::new(
+                Vec::new(),
+                HashSet::new(),
+                HashSet::new(),
+                HashMap::new(),
+                HashMap::new(),
+            ),
+            Sidebar::new(
+                Vec::new(),
+                HashSet::new(),
+                HashSet::new(),
+                HashMap::new(),
+                HashMap::new(),
+            ),
+            Vec::new(),
+            Dependency::new(HashMap::new()),
+            HashSet::new(),
+            Vec::<AnchorData>::new(),
+        )
+    }
+
+    pub(crate) fn run_pending_pass_skips_missing_embed_article_without_panicking() {
+        let root = unique_root("pending-pass-missing-embed");
+        let typst = root.join("typst");
+        let html = root.join("html");
+        write_test_config(&root);
+        fs::create_dir_all(&typst).expect("typst dir");
+        fs::create_dir_all(&html).expect("html dir");
+
+        let config = TypsiteConfig::load(&root, &typst, &html).expect("config should load");
+        let slug = Key::from("/article");
+        let articles = HashMap::from([(slug.clone(), article_with_title(&config, "/article"))]);
+        let global_data = GlobalData::new(
+            &config,
+            &articles,
+            HashMap::new(),
+            HashMap::from([(slug.clone(), Indexes::All)]),
+            HashMap::new(),
+        );
+        let embeds = vec![Embed::new(
+            Key::from("/missing-embed"),
+            false,
+            Vec::new(),
+            SectionType::Full,
+            SidebarPos::default(),
+            HashSet::new(),
+            HashSet::new(),
+            0,
+        )];
+        let content = (vec!["body".to_string()], Vec::new(), Vec::new());
+
+        let pending = PendingPass::new(slug, &global_data).run(&content, &embeds, &Indexes::All);
+
+        assert!(pending.embeds.is_empty());
+        assert_eq!(pending.raw.0, vec!["body".to_string()]);
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn pending_pass_skips_missing_embed_article_without_panicking() {
+        let _guard = crate::test_lock();
+        run_pending_pass_skips_missing_embed_article_without_panicking();
     }
 }

--- a/src/pass/pure.rs
+++ b/src/pass/pure.rs
@@ -1,11 +1,11 @@
 use crate::compile::registry::{Key, KeyRegistry, SlugPath};
-use crate::config::TypsiteConfig;
 use crate::config::rewrite::TagRewriteRule;
 use crate::config::schema::Schema;
-use crate::ir::article::Article;
+use crate::config::TypsiteConfig;
 use crate::ir::article::body::Body;
 use crate::ir::article::dep::{Dependency, Source, UpdatedIndex};
-use crate::ir::article::sidebar::{Pos, Sidebar, SidebarPos};
+use crate::ir::article::sidebar::{Pos, Sidebar, SidebarIndexes, SidebarPos};
+use crate::ir::article::Article;
 use crate::ir::embed::{EmbedVariables, SectionType};
 use crate::ir::pending::{AnchorData, AnchorKind};
 use crate::ir::rewriter::RewriterType;
@@ -16,7 +16,7 @@ use crate::pass::pure::metadata::MetadataBuilder;
 use crate::pass::pure::rewriter::RewriterBuilder;
 use crate::pass::pure::sidebar::PureSidebarBuilder;
 use crate::util::html::write_token;
-use crate::util::html::{Attributes, expect_start};
+use crate::util::html::{expect_start, Attributes};
 use crate::util::path::resolve_path;
 use crate::util::str::SectionElem;
 use anyhow::*;
@@ -120,6 +120,22 @@ impl<'a, 'k> PurePassData<'a> {
 }
 
 const TITLE_POS: SidebarPos = (vec![], 0);
+
+fn take_sidebar_title_indexes(
+    kind: &str,
+    pos: SidebarPos,
+    titles: &mut HashMap<SidebarPos, SidebarIndexes>,
+    missing: &mut Vec<(String, SidebarPos)>,
+) -> SidebarIndexes {
+    match titles.remove(&pos) {
+        Some(indexes) => indexes,
+        None => {
+            missing.push((kind.to_string(), pos));
+            SidebarIndexes::default()
+        }
+    }
+}
+
 impl<'a, 'b, 'c, 'k> PurePass<'a, 'k> {
     fn result(&mut self, result: Result<()>) {
         self.error.result(result);
@@ -153,10 +169,42 @@ impl<'a, 'b, 'c, 'k> PurePass<'a, 'k> {
             cache.as_ref().map(|it| it.get_meta_contents()),
         )?;
         let (mut full_sidebar, mut embed_sidebar) = data.sidebar.build(&data.config.sidebar);
-        let (body_content, body_rewriters, embeds) = body.build(
-            &mut |pos| full_sidebar.titles.remove(&pos).unwrap(),
-            &mut |pos| embed_sidebar.titles.remove(&pos).unwrap(),
-        );
+        let mut missing_full_sidebar_titles = Vec::new();
+        let mut missing_embed_sidebar_titles = Vec::new();
+        let (body_content, body_rewriters, embeds) = {
+            body.build(
+                &mut |pos| {
+                    take_sidebar_title_indexes(
+                        "full",
+                        pos,
+                        &mut full_sidebar.titles,
+                        &mut missing_full_sidebar_titles,
+                    )
+                },
+                &mut |pos| {
+                    take_sidebar_title_indexes(
+                        "embed",
+                        pos,
+                        &mut embed_sidebar.titles,
+                        &mut missing_embed_sidebar_titles,
+                    )
+                },
+            )
+        };
+        for (kind, pos) in missing_full_sidebar_titles {
+            error.add(anyhow!(
+                "Missing {kind} sidebar title slot for {} at {:?}",
+                slug,
+                pos
+            ));
+        }
+        for (kind, pos) in missing_embed_sidebar_titles {
+            error.add(anyhow!(
+                "Missing {kind} sidebar title slot for {} at {:?}",
+                slug,
+                pos
+            ));
+        }
         let body_numberings = data.numberings;
         let full_sidebar_show_children = full_sidebar.show_children;
         let full_sidebar_numberings = full_sidebar.numberings;
@@ -167,16 +215,44 @@ impl<'a, 'b, 'c, 'k> PurePass<'a, 'k> {
         let dependency = Dependency::new(data.dependency);
         let used_rules = data.used_rules;
         let body = Body::new(body_content, body_rewriters, body_numberings);
+        let mut missing_full_sidebar_title = Vec::new();
+        let full_sidebar_title = take_sidebar_title_indexes(
+            "full",
+            TITLE_POS,
+            &mut full_sidebar.titles,
+            &mut missing_full_sidebar_title,
+        );
+        for (kind, pos) in missing_full_sidebar_title {
+            error.add(anyhow!(
+                "Missing {kind} sidebar title slot for {} at {:?}",
+                slug,
+                pos
+            ));
+        }
         let full_sidebar = Sidebar::new(
             full_sidebar.contents,
-            full_sidebar.titles.remove(&TITLE_POS).unwrap_or_default(),
+            full_sidebar_title,
             full_sidebar_show_children,
             full_sidebar_numberings,
             full_sidebar_anchors,
         );
+        let mut missing_embed_sidebar_title = Vec::new();
+        let embed_sidebar_title = take_sidebar_title_indexes(
+            "embed",
+            TITLE_POS,
+            &mut embed_sidebar.titles,
+            &mut missing_embed_sidebar_title,
+        );
+        for (kind, pos) in missing_embed_sidebar_title {
+            error.add(anyhow!(
+                "Missing {kind} sidebar title slot for {} at {:?}",
+                slug,
+                pos
+            ));
+        }
         let embed_sidebar = Sidebar::new(
             embed_sidebar.contents,
-            embed_sidebar.titles.remove(&TITLE_POS).unwrap_or_default(),
+            embed_sidebar_title,
             embed_show_children,
             embed_sidebar_numberings,
             embed_sidebar_anchors,
@@ -225,7 +301,7 @@ impl<'a, 'b, 'c, 'k> PurePass<'a, 'k> {
             Self::push_body_buffer,
         )?;
         while let Some(level) = self.heading_level_backtrace.pop() {
-            self.push_section_end(level);
+            self.push_section_end(level)?;
         }
         Ok(())
     }
@@ -365,7 +441,11 @@ impl<'a, 'b, 'c, 'k> PurePass<'a, 'k> {
                     .rules
                     .get(tag.as_str())
                     .with_context(|| format!("No rewrite rule named {tag}"))?;
-                let tag_name = self.config.rules.rule_name(&tag).unwrap();
+                let tag_name = self
+                    .config
+                    .rules
+                    .rule_name(&tag)
+                    .with_context(|| format!("No rewrite rule named {tag}"))?;
                 self.used_rules.insert(tag_name);
 
                 self.push_rewriter_start(tag_name, rule, attrs)?;
@@ -388,14 +468,25 @@ impl<'a, 'b, 'c, 'k> PurePass<'a, 'k> {
             }
             BodyTag::MetaContentGet { attrs } => {
                 if let Some(meta_key) = &self.metadata.meta_key {
-                    let inner = attrs.get("get").unwrap();
+                    let inner = attrs
+                        .get("get")
+                        .map(|value| value.to_string())
+                        .unwrap_or_else(|| "<missing>".to_string());
                     return Err(anyhow!(
                         "[WARN] {}: Metadata CANNOT be embed in other Meta Content: {inner} in {meta_key}, skip",
                         self.slug
                     ));
                 } else {
-                    let rule = self.config.rules.get("metacontent").unwrap();
-                    let tag_name = self.config.rules.rule_name("metacontent").unwrap();
+                    let rule = self
+                        .config
+                        .rules
+                        .get("metacontent")
+                        .context("Built-in metacontent rewrite rule is missing")?;
+                    let tag_name = self
+                        .config
+                        .rules
+                        .rule_name("metacontent")
+                        .context("Built-in metacontent rewrite rule name is missing")?;
                     self.used_rules.insert(tag_name);
                     self.push_rewriter_start("metacontent", rule, attrs)?;
                 }
@@ -408,7 +499,7 @@ impl<'a, 'b, 'c, 'k> PurePass<'a, 'k> {
                 sidebar,
                 heading_level,
             } => {
-                self.push_section_ends_if_needed(heading_level);
+                self.push_section_ends_if_needed(heading_level)?;
                 self.push_embed(slug, open, variables, sidebar, heading_level)?;
             }
 
@@ -428,10 +519,10 @@ impl<'a, 'b, 'c, 'k> PurePass<'a, 'k> {
             }
 
             BodyTag::Section { heading_level } => {
-                self.push_section_ends_if_needed(heading_level);
+                self.push_section_ends_if_needed(heading_level)?;
                 let pos = self.sidebar.intake_heading(heading_level);
                 let before_title = self.config.section.before_title();
-                self.push_section(heading_level, before_title);
+                self.push_section(heading_level, before_title)?;
                 self.sidebar_pos = Some((pos, 0));
             }
         }
@@ -446,7 +537,11 @@ impl<'a, 'b, 'c, 'k> PurePass<'a, 'k> {
                     .rules
                     .get(tag.as_str())
                     .with_context(|| format!("No rewrite rule named {tag}"))?;
-                let tag_name = self.config.rules.rule_name(tag.as_str()).unwrap();
+                let tag_name = self
+                    .config
+                    .rules
+                    .rule_name(tag.as_str())
+                    .with_context(|| format!("No rewrite rule named {tag}"))?;
                 self.push_rewriter_end(tag_name, rule)?;
             }
             BodyTag::MetaContentSet { .. } if self.metadata.meta_key.is_some() => {
@@ -458,9 +553,9 @@ impl<'a, 'b, 'c, 'k> PurePass<'a, 'k> {
             }
             BodyTag::Section { heading_level } => {
                 self.sidebar_pos = None;
-                self.push_section_start(heading_level);
+                self.push_section_start(heading_level)?;
                 let buffer = std::mem::take(&mut self.content_buffer);
-                self.sidebar.add_heading_section(heading_level, buffer);
+                self.sidebar.add_heading_section(heading_level, buffer)?;
             }
             _ => {}
         }
@@ -468,28 +563,30 @@ impl<'a, 'b, 'c, 'k> PurePass<'a, 'k> {
         Ok(())
     }
 
-    fn push_section_start(&mut self, level: usize) {
+    fn push_section_start(&mut self, level: usize) -> Result<()> {
         let before_title = self.config.section.before_content();
-        self.push_section(level, before_title);
+        self.push_section(level, before_title)?;
         self.heading_level_backtrace.push(level);
+        Ok(())
     }
-    fn push_section_end(&mut self, level: usize) {
+    fn push_section_end(&mut self, level: usize) -> Result<()> {
         let after_content = self.config.section.after_content();
-        self.push_section(level, after_content);
+        self.push_section(level, after_content)
     }
 
-    fn push_section_ends_if_needed(&mut self, current_level: usize) {
+    fn push_section_ends_if_needed(&mut self, current_level: usize) -> Result<()> {
         while let Some(&last_level) = self.heading_level_backtrace.last() {
             if current_level <= last_level {
                 self.heading_level_backtrace.pop();
-                self.push_section_end(last_level);
+                self.push_section_end(last_level)?;
             } else {
                 break;
             }
         }
+        Ok(())
     }
 
-    pub fn push_section(&mut self, level: usize, elems: &[SectionElem]) {
+    pub fn push_section(&mut self, level: usize, elems: &[SectionElem]) -> Result<()> {
         let pos = self.sidebar.current_full_pos();
         for elem in elems {
             match elem {
@@ -497,14 +594,22 @@ impl<'a, 'b, 'c, 'k> PurePass<'a, 'k> {
                 SectionElem::HeadingNumbering => self.push_heading_numbering(pos.clone()),
                 SectionElem::Level => self.push_plain(level.to_string()),
                 SectionElem::Content | SectionElem::Title => {
-                    panic!("Unexpected title/content in before_title in section.html")
+                    return Err(anyhow!(
+                        "Unexpected section placeholder found outside content/title slot in {}",
+                        self.slug
+                    ));
                 }
             }
         }
+        Ok(())
     }
 
     pub fn resolve_slug(&self, slug_path: &str, tag: &str) -> Result<Key> {
-        let path = resolve_path(self.root, self.path.parent().unwrap(), slug_path)?;
+        let parent = self
+            .path
+            .parent()
+            .context("article source path should always have a parent directory")?;
+        let path = resolve_path(self.root, parent, slug_path)?;
         let slug = self.config.path_to_slug(path.as_path())?;
 
         self.registry.slug(slug.as_str()).with_context(|| {
@@ -617,7 +722,10 @@ impl<'a, 'b, 'c, 'k> PurePass<'a, 'k> {
     }
 
     fn push_rewriter_end(&mut self, rule_id: &'a str, rule: &'a TagRewriteRule) -> Result<()> {
-        let attrs = self.rewriter_backtrace.pop().unwrap();
+        let attrs = self
+            .rewriter_backtrace
+            .pop()
+            .context("rewrite end tag encountered without matching start tag")?;
         let attrs = match attrs {
             Some(attrs) => attrs,
             None => return Ok(()),
@@ -655,7 +763,8 @@ impl<'a, 'b, 'c, 'k> PurePass<'a, 'k> {
         let body_index = self.body.len();
         let section_type = SectionType::from(sidebar);
 
-        let (full_sidebar_pos, embed_sidebar_pos) = self.sidebar.add_embed_section(heading_level);
+        let (full_sidebar_pos, embed_sidebar_pos) =
+            self.sidebar.add_embed_section(heading_level)?;
 
         let full_sidebar_pos = (full_sidebar_pos, 0);
         let embed_sidebar_pos = (embed_sidebar_pos, 0);
@@ -709,5 +818,115 @@ impl<'a, 'b, 'c, 'k> PurePass<'a, 'k> {
             .entry(Source::Article(slug))
             .or_default()
             .insert(UpdatedIndex::Embed(index));
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::metadata::MetadataBuilder;
+    use super::sidebar::{Section, SidebarBuilder};
+    use super::{take_sidebar_title_indexes, TITLE_POS};
+    use crate::compile::error::TypError;
+    use crate::compile::{init_proj_options, options::ProjOptions, registry::Key};
+    use anyhow::anyhow;
+    use std::collections::HashMap;
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn unique_root(label: &str) -> std::path::PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("test timestamp should be available")
+            .as_nanos();
+        std::env::temp_dir().join(format!("typsite-{label}-{unique}"))
+    }
+
+    pub(crate) fn run_sidebar_builder_reports_invalid_parent_section() {
+        let mut builder = SidebarBuilder::new(Key::from("/article"));
+        builder.sections = Section::new_embed("article".to_string());
+        builder.pos = vec![0];
+
+        let err = builder
+            .add_section(1, vec!["Heading".to_string()])
+            .expect_err("invalid parent section should return a contextual error");
+
+        assert!(err.to_string().contains("under embed section"));
+    }
+
+    pub(crate) fn run_pure_pass_reports_missing_sidebar_title_slot() {
+        let slug = Key::from("/article");
+        let mut error = TypError::new(slug.clone());
+        let mut missing = Vec::new();
+        let indexes =
+            take_sidebar_title_indexes("full", TITLE_POS, &mut HashMap::new(), &mut missing);
+
+        for (kind, pos) in missing {
+            error.add(anyhow!(
+                "Missing {kind} sidebar title slot for {} at {:?}",
+                slug,
+                pos
+            ));
+        }
+
+        assert!(indexes.is_empty());
+        assert!(error.has_error());
+        assert!(format!("{error}").contains("Missing full sidebar title slot"));
+    }
+
+    pub(crate) fn run_metadata_builder_reports_unbalanced_metacontent_state() {
+        let root = unique_root("metadata-builder-state");
+        fs::create_dir_all(&root).expect("root dir");
+        fs::write(
+            root.join("options.toml"),
+            r#"
+[default_metadata.content]
+title = "Fallback Title"
+
+[default_metadata.options]
+heading_numbering = "Bullet"
+sidebar_type = "All"
+
+[default_metadata.graph]
+parent = "/"
+
+[typst_lib]
+paths = []
+
+[code_fallback_style]
+dark = "dark"
+light = "light"
+"#,
+        )
+        .expect("options file");
+        let proj = ProjOptions::load(&root).expect("project options should load");
+        init_proj_options(proj).expect("project options should initialize");
+
+        let mut builder = MetadataBuilder::new(Key::from("/article"));
+        builder.emit_metacontent_end(vec!["orphan".to_string()]);
+        let err = builder
+            .build(Key::from("/article"), None)
+            .expect_err("closing metacontent without an open key should return an error");
+
+        assert!(err.to_string().contains("Unbalanced metacontent close"));
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn sidebar_builder_reports_invalid_parent_section() {
+        let _guard = crate::test_lock();
+        run_sidebar_builder_reports_invalid_parent_section();
+    }
+
+    #[test]
+    fn pure_pass_reports_missing_sidebar_title_slot() {
+        let _guard = crate::test_lock();
+        run_pure_pass_reports_missing_sidebar_title_slot();
+    }
+
+    #[test]
+    fn metadata_builder_reports_unbalanced_metacontent_state() {
+        let _guard = crate::test_lock();
+        run_metadata_builder_reports_unbalanced_metacontent_state();
     }
 }

--- a/src/pass/pure/body.rs
+++ b/src/pass/pure/body.rs
@@ -1,10 +1,10 @@
 use crate::compile::error::TypError;
+use crate::ir::article::sidebar::{SidebarIndexes, SidebarPos};
 use crate::ir::embed::Embed;
 use crate::ir::rewriter::BodyRewriter;
-use crate::ir::article::sidebar::{SidebarIndexes, SidebarPos};
-use crate::pass::pure::PurePassData;
 use crate::pass::pure::embed::EmbedBuilder;
 use crate::pass::pure::rewriter::RewriterBuilder;
+use crate::pass::pure::PurePassData;
 
 #[derive(Default)]
 pub struct BodyBuilder<'a> {
@@ -48,7 +48,7 @@ impl<'a> BodyBuilder<'a> {
         self.body.len()
     }
 
-    pub fn build_rewriter_attrs(&mut self, data: &PurePassData, error: &mut TypError)  {
+    pub fn build_rewriter_attrs(&mut self, data: &PurePassData, error: &mut TypError) {
         for rewriter in self.rewriters.iter_mut() {
             error.result(rewriter.build_attr(data));
         }

--- a/src/pass/pure/footnote.rs
+++ b/src/pass/pure/footnote.rs
@@ -19,15 +19,18 @@ impl FootNotesData {
         }
     }
 
-    pub fn add_footnote(&mut self, name: String) -> (String,usize) {
+    pub fn add_footnote(&mut self, name: String) -> (String, usize) {
         let index = self.footnotes.len() + 1;
         let name = if name == NUMBERING_NAME {
             numbering_name(index)
         } else {
             name
         };
-        self.footnotes.push(FootNote { index, name:name.clone() });
-        (name,index)
+        self.footnotes.push(FootNote {
+            index,
+            name: name.clone(),
+        });
+        (name, index)
     }
 
     pub fn get_numbering(&self, name: &str) -> Option<usize> {

--- a/src/pass/pure/metadata.rs
+++ b/src/pass/pure/metadata.rs
@@ -7,6 +7,7 @@ use crate::ir::metadata::options::MetaOptions;
 use crate::ir::metadata::Metadata;
 use crate::ir::rewriter::MetaRewriter;
 use crate::pass::pure::rewriter::RewriterBuilder;
+use anyhow::anyhow;
 use std::collections::{HashMap, HashSet};
 
 pub struct MetadataBuilder<'a> {
@@ -21,11 +22,13 @@ pub struct MetadataBuilder<'a> {
     parent: Option<Key>,
     cited: HashSet<Key>,
     children: HashSet<Key>,
+    errors: Vec<anyhow::Error>,
 }
 
 impl<'a> MetadataBuilder<'a> {
     pub fn new(self_slug: Key) -> Self {
-        let options = proj_options().unwrap();
+        let options = proj_options()
+            .expect("project options should be initialized before parsing article metadata");
 
         let heading_numbering_style = options.default_metadata.options.heading_numbering;
         let sidebar_type = options.default_metadata.options.sidebar_type;
@@ -53,6 +56,7 @@ impl<'a> MetadataBuilder<'a> {
             parent,
             cited: HashSet::new(),
             children: HashSet::new(),
+            errors: Vec::new(),
         }
     }
 
@@ -99,9 +103,16 @@ impl<'a> MetadataBuilder<'a> {
     }
 
     pub fn emit_metacontent_end(&mut self, content: Vec<String>) {
+        let Some(metadata_key) = self.meta_key.take() else {
+            self.errors.push(anyhow!(
+                "Unbalanced metacontent close for {}: closing a metadata content block without an open key",
+                self.slug
+            ));
+            self.meta_rewriter_buffer.clear();
+            return;
+        };
         let atom_buffer = std::mem::take(&mut self.meta_rewriter_buffer);
         let content = MetaContent::new(content, atom_buffer);
-        let metadata_key = self.meta_key.take().unwrap();
         self.contents.insert(metadata_key, content);
     }
 
@@ -114,10 +125,19 @@ impl<'a> MetadataBuilder<'a> {
     }
 
     pub(crate) fn build(
-        self,
+        mut self,
         slug: Key,
         cache: Option<&MetaContents<'a>>,
     ) -> anyhow::Result<Metadata<'a>> {
+        if !self.errors.is_empty() {
+            let details = self
+                .errors
+                .drain(..)
+                .map(|error| error.to_string())
+                .collect::<Vec<_>>()
+                .join("; ");
+            return Err(anyhow!(details));
+        }
         let updated = cache
             .as_ref()
             .map(|cache| !cache.same_contents(&self.contents))

--- a/src/pass/pure/rewriter.rs
+++ b/src/pass/pure/rewriter.rs
@@ -1,6 +1,7 @@
-use crate::ir::rewriter::{BodyRewriter, MetaRewriter, RewriterType};
 use crate::ir::article::sidebar::{SidebarIndexes, SidebarPos};
+use crate::ir::rewriter::{BodyRewriter, MetaRewriter, RewriterType};
 use crate::pass::pure::PurePassData;
+use anyhow::Context;
 use std::collections::HashMap;
 use std::mem;
 
@@ -39,7 +40,12 @@ impl<'a> RewriterBuilder<'a> {
     }
 
     pub fn build_attr(&mut self, data: &PurePassData) -> anyhow::Result<()> {
-        let rule = data.config.rules.get(self.id).unwrap();
+        let rule = data.config.rules.get(self.id).with_context(|| {
+            format!(
+                "No rewrite rule named {} while building attributes",
+                self.id
+            )
+        })?;
         let attribute = mem::take(&mut self.attributes);
         self.attributes = rule.pass.build_attr(attribute, data)?;
         Ok(())

--- a/src/pass/pure/sidebar.rs
+++ b/src/pass/pure/sidebar.rs
@@ -3,6 +3,7 @@ use crate::config::sidebar::SidebarConfig;
 use crate::ir::article::sidebar::{HeadingNumberingStyle, Pos, SidebarIndexes, SidebarPos};
 use crate::util::pos_slug;
 use crate::util::str::SidebarElem;
+use anyhow::{anyhow, Result};
 use std::cmp::{Ordering, PartialEq};
 use std::collections::{HashMap, HashSet};
 
@@ -141,10 +142,10 @@ impl<'a> SidebarData<'a> {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-struct SidebarBuilder {
+pub(crate) struct SidebarBuilder {
     slug: Key,
-    pos: Pos,
-    sections: Section,
+    pub(crate) pos: Pos,
+    pub(crate) sections: Section,
 }
 
 impl SidebarBuilder {
@@ -152,8 +153,12 @@ impl SidebarBuilder {
         SidebarData::build(config, self.sections)
     }
 
-    fn new(slug: Key) -> Self {
-        let anchor = slug.as_ref()[1..].to_string();
+    pub(crate) fn new(slug: Key) -> Self {
+        let anchor = slug
+            .as_ref()
+            .strip_prefix('/')
+            .expect("article slugs should always be normalized with a leading slash")
+            .to_string();
         Self {
             slug,
             pos: vec![],
@@ -181,12 +186,9 @@ impl SidebarBuilder {
     fn get_section_mut<'a>(sections: &'a mut Section, pos: &[usize]) -> Option<&'a mut Section> {
         let mut current = sections;
         for &index in pos {
-            current = match &current.data {
-                SectionData::Inner { .. } => match &mut current.data {
-                    SectionData::Inner { children, .. } => children.get_mut(index).unwrap(),
-                    _ => panic!(),
-                },
-                SectionData::Embed => panic!(),
+            current = match &mut current.data {
+                SectionData::Inner { children, .. } => children.get_mut(index)?,
+                SectionData::Embed => return None,
             };
         }
         Some(current)
@@ -223,16 +225,23 @@ impl SidebarBuilder {
             Ordering::Greater => {
                 self.pos.push(0);
             }
-            Ordering::Equal => *self.pos.last_mut().unwrap() += 1,
+            Ordering::Equal => {
+                if let Some(last) = self.pos.last_mut() {
+                    *last += 1;
+                }
+            }
             Ordering::Less => {
-                let mut last_pos: usize = *pos.last().unwrap();
+                let mut last_pos: usize = pos.last().copied().unwrap_or_default();
                 while !pos.is_empty() {
                     if self.get_level(&pos) < level {
                         pos.append(&mut vec![last_pos + 1]);
                         self.pos = pos.clone();
                         break;
                     }
-                    last_pos = pos.pop().unwrap();
+                    let Some(next_last_pos) = pos.pop() else {
+                        break;
+                    };
+                    last_pos = next_last_pos;
                 }
                 if pos.is_empty() {
                     self.pos = vec![last_pos + 1];
@@ -242,36 +251,57 @@ impl SidebarBuilder {
         self.pos.clone()
     }
 
-    fn add_section(&mut self, level: usize, title: Vec<String>) {
+    pub(crate) fn add_section(&mut self, level: usize, title: Vec<String>) -> Result<()> {
         let mut pos = self.pos.clone();
         let section = Section::new(level, pos_slug(&pos, self.slug.as_ref()), title);
         pos.pop();
-        let parent = Self::get_section_mut(&mut self.sections, &pos).unwrap();
+        let parent = Self::get_section_mut(&mut self.sections, &pos).ok_or_else(|| {
+            anyhow!(
+                "Failed to find sidebar parent section while adding heading level {level} for {} at {:?}",
+                self.slug,
+                self.pos
+            )
+        })?;
         match &mut parent.data {
             SectionData::Inner { children, .. } => {
                 children.push(section);
+                Ok(())
             }
-            SectionData::Embed => panic!("Parent section is an embed section"),
+            SectionData::Embed => Err(anyhow!(
+                "Failed to add sidebar heading level {level} under embed section for {} at {:?}",
+                self.slug,
+                self.pos
+            )),
         }
     }
 
-    fn add_embed_section(&mut self, level: usize) -> Pos {
+    fn add_embed_section(&mut self, level: usize) -> Result<Pos> {
         self.intake(level);
         let parent_pos = {
             let mut pos = self.pos.clone();
             pos.pop();
             pos
         };
-        let parent = Self::get_section_mut(&mut self.sections, &parent_pos).unwrap();
+        let parent = Self::get_section_mut(&mut self.sections, &parent_pos).ok_or_else(|| {
+            anyhow!(
+                "Failed to find sidebar parent section while adding embed level {level} for {} at {:?}",
+                self.slug,
+                self.pos
+            )
+        })?;
         match &mut parent.data {
             SectionData::Inner { children, .. } => {
                 let anchor_str = pos_slug(&self.pos, self.slug.as_ref());
                 children.push(Section::new_embed(anchor_str));
+                Ok(self.pos.clone())
             }
 
-            SectionData::Embed => panic!("Parent section is an embed section"),
+            SectionData::Embed => Err(anyhow!(
+                "Failed to add embed sidebar section under embed section for {} at {:?}",
+                self.slug,
+                self.pos
+            )),
         }
-        self.pos.clone()
     }
 }
 
@@ -292,17 +322,17 @@ impl PureSidebarBuilder {
         self.full_sidebar.intake(level)
     }
 
-    pub fn add_heading_section(&mut self, level: usize, title: Vec<String>) {
-        self.full_sidebar.add_section(level, title);
+    pub fn add_heading_section(&mut self, level: usize, title: Vec<String>) -> Result<()> {
+        self.full_sidebar.add_section(level, title)
     }
     pub fn current_full_pos(&self) -> Pos {
         self.full_sidebar.pos.clone()
     }
 
-    pub fn add_embed_section(&mut self, level: usize) -> (Pos, Pos) {
-        let full_sidebar_index = self.full_sidebar.add_embed_section(level);
-        let only_embed_index = self.only_embed_sidebar.add_embed_section(level);
-        (full_sidebar_index, only_embed_index)
+    pub fn add_embed_section(&mut self, level: usize) -> Result<(Pos, Pos)> {
+        let full_sidebar_index = self.full_sidebar.add_embed_section(level)?;
+        let only_embed_index = self.only_embed_sidebar.add_embed_section(level)?;
+        Ok((full_sidebar_index, only_embed_index))
     }
 
     pub fn build(self, config: &SidebarConfig) -> (SidebarData<'_>, SidebarData<'_>) {

--- a/src/pass/rewrite.rs
+++ b/src/pass/rewrite.rs
@@ -1,8 +1,8 @@
+use crate::compile::registry::Key;
+use crate::config::TypsiteConfig;
 use crate::ir::article::data::GlobalData;
 use crate::ir::article::dep::{Indexes, Source};
 use crate::ir::rewriter::{BodyRewriter, MetaRewriter, RewriterType};
-use crate::compile::registry::Key;
-use crate::config::TypsiteConfig;
 use crate::pass::pure::{PurePass, PurePassData};
 use crate::util::html::Attributes;
 use anyhow::*;
@@ -19,17 +19,24 @@ mod footnote_ref_svg;
 
 pub const METACONTENT_TAG: &str = "metacontent";
 
-    static REWRITE_PASSES: LazyLock<Arc<Mutex<HashMap<String, Arc<dyn TagRewritePass>>>>> =
-        LazyLock::new(|| Arc::new(Mutex::new(HashMap::new())));
+static REWRITE_PASSES: LazyLock<Arc<Mutex<HashMap<String, Arc<dyn TagRewritePass>>>>> =
+    LazyLock::new(|| Arc::new(Mutex::new(HashMap::new())));
 
 pub fn register_rewrite_pass(rewriter: impl TagRewritePass + 'static) {
     let tag = rewriter.id().to_string();
     let arc_instance = Arc::new(rewriter);
-    REWRITE_PASSES.lock().unwrap().insert(tag, arc_instance);
+    REWRITE_PASSES
+        .lock()
+        .expect("rewrite pass registry mutex should not be poisoned")
+        .insert(tag, arc_instance);
 }
 
 pub fn find_rewrite_pass(tag: &str) -> Option<Arc<dyn TagRewritePass>> {
-    REWRITE_PASSES.lock().unwrap().get(tag).map(Arc::clone)
+    REWRITE_PASSES
+        .lock()
+        .expect("rewrite pass registry mutex should not be poisoned")
+        .get(tag)
+        .map(Arc::clone)
 }
 
 pub trait Id {
@@ -54,11 +61,7 @@ pub trait Purity {
 #[allow(unused_variables)]
 pub trait TagRewritePass: Id + Atom + Send + Sync + Purity {
     // Initialize the pass, return the attributes to be passed to the following functions
-    fn init(
-        &self,
-        attrs: Attributes,
-        pass: &mut PurePass,
-    ) -> Result<HashMap<String, String>>;
+    fn init(&self, attrs: Attributes, pass: &mut PurePass) -> Result<HashMap<String, String>>;
 
     // Build the attributes, called when the whole HTML is passed
     fn build_attr(
@@ -193,12 +196,7 @@ impl<'c, 'b: 'c, 'a: 'b> RewritePass<'a, 'b, 'c> {
         }
     }
 
-    pub fn run_meta(
-        self,
-        body: &mut [String],
-        rewriters: &Vec<MetaRewriter>,
-        indexes: &Indexes,
-    ) {
+    pub fn run_meta(self, body: &mut [String], rewriters: &Vec<MetaRewriter>, indexes: &Indexes) {
         match indexes {
             Indexes::All => {
                 for rewriter in rewriters {
@@ -237,7 +235,9 @@ impl<'c, 'b: 'c, 'a: 'b> RewritePass<'a, 'b, 'c> {
         if str.is_none() {
             return;
         }
-        let str = str.unwrap();
+        let Some(str) = str else {
+            return;
+        };
         for index in sidebar_indexes {
             sidebar[*index] = str.clone();
         }
@@ -260,7 +260,35 @@ impl<'c, 'b: 'c, 'a: 'b> RewritePass<'a, 'b, 'c> {
         if str.is_none() {
             return;
         }
-        let str = str.unwrap();
+        let Some(str) = str else {
+            return;
+        };
         contents[*index] = str;
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use crate::pass::tokenizer::{BodyTag, Event, EventTokenizer, Tokenizer};
+
+    pub(crate) fn run_rewrite_pass_reports_missing_required_attr() {
+        let html = "<body><rewrite></rewrite></body>";
+        let mut raw = html5gum::Tokenizer::new(html).peekable();
+        let mut tokenizer = Tokenizer::<BodyTag>::new(&mut raw);
+        let err = loop {
+            match tokenizer.next() {
+                Some(Err(err)) => break err,
+                Some(Ok(Event::Eof)) => panic!("missing rewrite id should have produced an error"),
+                Some(Ok(_)) => {}
+                None => panic!("missing rewrite id should have produced an error"),
+            }
+        };
+
+        assert!(err.to_string().contains("Rewrite: expect id attribute"));
+    }
+
+    #[test]
+    fn rewrite_pass_reports_missing_required_attr() {
+        run_rewrite_pass_reports_missing_required_attr();
     }
 }

--- a/src/pass/rewrite/cite.rs
+++ b/src/pass/rewrite/cite.rs
@@ -16,7 +16,9 @@ impl TagRewritePass for CitePass {
         if slug.is_none() {
             return Err(anyhow!("CiteRule: expect slug attribute"));
         }
-        let slug = slug.unwrap();
+        let Some(slug) = slug else {
+            return Err(anyhow!("CiteRule: expect slug attribute"));
+        };
         let slug = pass.resolve_slug(slug.as_ref(), "Cite")?;
         pass.metadata.add_cite(slug.clone());
         let anchor = attrs

--- a/src/pass/rewrite/code/highlighter.rs
+++ b/src/pass/rewrite/code/highlighter.rs
@@ -1,6 +1,5 @@
-
 use syntect::highlighting::{HighlightIterator, HighlightState, Highlighter, Theme};
-use syntect::html::{IncludeBackground, append_highlighted_html_for_styled_line};
+use syntect::html::{append_highlighted_html_for_styled_line, IncludeBackground};
 use syntect::parsing::{ParseState, ScopeStack, SyntaxReference, SyntaxSet};
 use syntect::util::LinesWithEndings;
 
@@ -43,12 +42,18 @@ pub fn highlight(
                 IncludeBackground::No,
                 &mut output,
             )
-            .unwrap();
+            .expect("writing highlighted HTML into a String should be infallible");
         }
     }
     output
 }
 
 fn apply_fallback_style(color: &str, text: &str) -> String {
-    format!("<span style='color:{color};'>{text}</span>")
+    let escaped = text
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#39;");
+    format!("<span style='color:{color};'>{escaped}</span>")
 }

--- a/src/pass/rewrite/code/mod.rs
+++ b/src/pass/rewrite/code/mod.rs
@@ -11,6 +11,27 @@ pub mod highlighter;
 
 rewrite_pass![CodeBlockPass, id = "code", atom = true];
 
+fn normalized_lang(attrs: &HashMap<String, String>) -> &str {
+    attrs
+        .get("lang")
+        .map(|value| value.as_str())
+        .expect("code rewrite pass should always carry a normalized `lang` attribute after init")
+}
+
+fn normalized_theme(attrs: &HashMap<String, String>) -> &str {
+    attrs
+        .get("theme")
+        .map(|value| value.as_str())
+        .expect("code rewrite pass should always carry a normalized `theme` attribute after init")
+}
+
+fn normalized_content(attrs: &HashMap<String, String>) -> &str {
+    attrs
+        .get("content")
+        .map(|value| value.as_str())
+        .expect("code rewrite pass should always carry a normalized `content` attribute after init")
+}
+
 impl TagRewritePass for CodeBlockPass {
     fn init(&self, mut attrs: Attributes, _: &mut PurePass) -> Result<HashMap<String, String>> {
         let lang = attrs.take("lang")?;
@@ -31,7 +52,7 @@ impl TagRewritePass for CodeBlockPass {
         pass: &PurePass<'a, '_>,
     ) -> Result<HashSet<Source>> {
         let mut path = HashSet::new();
-        let lang = attrs.get("lang").unwrap();
+        let lang = normalized_lang(attrs);
         let config = &pass.config.highlight;
         if !config.is_syntax_by_default(lang) {
             let syntax = config
@@ -42,7 +63,7 @@ impl TagRewritePass for CodeBlockPass {
                 path.insert(Source::Path(metadata_path));
             }
         }
-        let theme = attrs.get("theme").unwrap();
+        let theme = normalized_theme(attrs);
         let (light, dark) = config.find_theme_path_pair(theme).with_context(|| {
             format!("Can't find theme path pair(light & dark) for theme {theme}")
         })?;
@@ -57,13 +78,18 @@ impl TagRewritePass for CodeBlockPass {
         config: &TypsiteConfig,
         body: &str,
     ) -> Option<String> {
-        let lang = attrs.get("lang")?;
-        let theme = attrs.get("theme")?;
-        let content = attrs.get("content")?;
+        let lang = normalized_lang(attrs);
+        let theme = normalized_theme(attrs);
+        let content = normalized_content(attrs);
         let syntax = config.highlight.find_syntax(lang);
         let syntax_set = config.highlight.syntax_set(lang);
-        let (light, dark) = config.highlight.find_theme(theme)?;
-        let fallback = &proj_options().unwrap().code_fallback_style;
+        let (light, dark) = config.highlight.find_theme(theme).expect(
+            "code rewrite pass should only render with themes validated during dependency discovery",
+        );
+        let fallback = proj_options()
+            .expect("project options should be initialized before code highlighting")
+            .code_fallback_style
+            .clone();
         let light = highlight(syntax_set, syntax, content, light, &fallback.light);
         let dark = highlight(syntax_set, syntax, content, dark, &fallback.dark);
         Some(ac_replace(

--- a/src/pass/rewrite/footnote.rs
+++ b/src/pass/rewrite/footnote.rs
@@ -13,7 +13,9 @@ impl TagRewritePass for FootnoteRef {
         if name.is_none() {
             return Err(anyhow!("FootnoteRefRule: expect name attribute"));
         }
-        let name = name.unwrap();
+        let Some(name) = name else {
+            return Err(anyhow!("FootnoteRefRule: expect name attribute"));
+        };
         Ok([(String::from("name"), name.to_string())]
             .into_iter()
             .collect())
@@ -69,7 +71,9 @@ impl TagRewritePass for FootnoteDef {
         if name.is_none() {
             return Err(anyhow!("FootnoteDefRule: expect name attribute"));
         }
-        let name = name.unwrap();
+        let Some(name) = name else {
+            return Err(anyhow!("FootnoteDefRule: expect name attribute"));
+        };
         let (name, numbering) = pure.add_footnote(name.to_string());
         Ok([
             (String::from("name"), name.to_string()),

--- a/src/pass/rewrite/footnote_ref_svg.rs
+++ b/src/pass/rewrite/footnote_ref_svg.rs
@@ -28,8 +28,12 @@ impl TagRewritePass for FootnoteRef {
                 attrs
             ));
         }
-        let name = name.unwrap();
-        let transform = transform.unwrap();
+        let Some(name) = name else {
+            return Err(anyhow!("FootnoteRefSvgRule: expect name attribute"));
+        };
+        let Some(transform) = transform else {
+            return Err(anyhow!("FootnoteRefSvgRule: expect transform attribute"));
+        };
         Ok([
             (String::from("name"), name.to_string()),
             (String::from("transform"), transform.to_string()),

--- a/src/pass/rewrite/metacontent.rs
+++ b/src/pass/rewrite/metacontent.rs
@@ -22,8 +22,12 @@ impl TagRewritePass for MetaContentPass {
         if meta_key.is_none() {
             return Err(anyhow!("Metacontent-Get: expect `meta_key` attribute"));
         }
-        let slug = slug.unwrap();
-        let meta_key = meta_key.unwrap();
+        let Some(slug) = slug else {
+            return Err(anyhow!("Metacontent-Get: expect `from` attribute"));
+        };
+        let Some(meta_key) = meta_key else {
+            return Err(anyhow!("Metacontent-Get: expect `meta_key` attribute"));
+        };
         let slug = if slug == "$self" {
             pass.slug.clone()
         } else {
@@ -42,7 +46,9 @@ impl TagRewritePass for MetaContentPass {
         attrs: &HashMap<String, String>,
         pass: &PurePass<'a, '_>,
     ) -> Result<HashSet<Source>> {
-        let slug = attrs.get("from").unwrap();
+        let Some(slug) = attrs.get("from") else {
+            return Ok(HashSet::default());
+        };
         if slug == pass.slug.as_ref() {
             return Ok(HashSet::default());
         }

--- a/src/pass/schema.rs
+++ b/src/pass/schema.rs
@@ -45,10 +45,18 @@ impl<'d, 'c: 'd, 'b: 'c, 'a: 'b> SchemaPass<'a, 'b, 'c, 'd> {
     }
 
     pub fn run(mut self) -> TypResult<OutputHtml<'a>> {
-        let metadata = self
+        let mut err = TypError::new_schema(self.article.slug.clone(), self.schema.id.as_str());
+        let metadata = err.ok(self
             .global_data
             .metadata(self.article.slug.as_ref())
-            .unwrap();
+            .with_context(|| format!("Metadata of {} not found", self.article.slug)));
+        if err.has_error() {
+            return Err(err);
+        }
+        let Some(metadata) = metadata else {
+            let err = anyhow::anyhow!("Metadata unexpectedly missing for {}", self.article.slug);
+            return Err(TypError::new_with(self.article.slug.clone(), vec![err]));
+        };
 
         let footer_schema = matches!(self.schema.id.as_str(), REFERENCE_KEY | BACKLINK_KEY);
 
@@ -137,7 +145,7 @@ impl<'d, 'c: 'd, 'b: 'c, 'a: 'b> SchemaPass<'a, 'b, 'c, 'd> {
                     let attrs = Attributes::new(tag.attributes);
                     let meta_key = attrs
                         .expect("get")
-                        .context("Expect Metadata tag with attr `get`");
+                        .context("Expected <metadata> tag with required attr `get`");
                     let meta_key = err.ok(meta_key);
                     let from = attrs.get("from").unwrap_or(Cow::Borrowed("$self"));
                     let metadata = match from.as_ref() {
@@ -195,5 +203,207 @@ impl<'d, 'c: 'd, 'b: 'c, 'a: 'b> SchemaPass<'a, 'b, 'c, 'd> {
         }
         let html = OutputHtml::<'a>::new(head, self.body);
         Ok(html)
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use crate::compile::{
+        init_compile_options, init_proj_options,
+        options::{CompileOptions, ProjOptions},
+    };
+    use crate::config::TypsiteConfig;
+    use crate::ir::article::body::Body;
+    use crate::ir::article::data::GlobalData;
+    use crate::ir::article::dep::{Dependency, Indexes};
+    use crate::ir::article::{sidebar::Sidebar, Article};
+    use crate::ir::metadata::content::MetaContents;
+    use crate::ir::metadata::graph::MetaNode;
+    use crate::ir::metadata::options::MetaOptions;
+    use crate::ir::metadata::Metadata;
+    use std::collections::{HashMap, HashSet};
+    use std::fs;
+    use std::sync::OnceLock;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn write_test_config(root: &std::path::Path) {
+        fs::create_dir_all(root.join("components/footer")).expect("footer dir");
+        fs::create_dir_all(root.join("rewrite")).expect("rewrite dir");
+        fs::create_dir_all(root.join("schemas")).expect("schema dir");
+        fs::create_dir_all(root.join("syntaxes")).expect("syntaxes dir");
+        fs::create_dir_all(root.join("themes")).expect("themes dir");
+
+        fs::write(
+            root.join("options.toml"),
+            include_str!("../../resources/.typsite/options.toml"),
+        )
+        .expect("options file");
+        fs::write(
+            root.join("components/section.html"),
+            include_str!("../../resources/.typsite/components/section.html"),
+        )
+        .expect("section");
+        fs::write(
+            root.join("components/heading-numbering.html"),
+            "<html><body>{numbering}</body></html>",
+        )
+        .expect("heading numbering");
+        fs::write(
+            root.join("components/footer.html"),
+            "<html><body><footer>{references}{backlinks}</footer></body></html>",
+        )
+        .expect("footer");
+        fs::write(
+            root.join("components/footer/backlinks.html"),
+            "<html><body>{backlinks}</body></html>",
+        )
+        .expect("backlinks");
+        fs::write(
+            root.join("components/footer/references.html"),
+            "<html><body>{references}</body></html>",
+        )
+        .expect("references");
+        fs::write(
+            root.join("components/anchor_def.html"),
+            "<html><body></body></html>",
+        )
+        .expect("anchor def");
+        fs::write(
+            root.join("components/anchor_def_svg.html"),
+            "<html><body></body></html>",
+        )
+        .expect("anchor def svg");
+        fs::write(
+            root.join("components/anchor_goto.html"),
+            "<html><body></body></html>",
+        )
+        .expect("anchor goto");
+        fs::write(
+            root.join("components/anchor_goto_svg.html"),
+            "<html><body></body></html>",
+        )
+        .expect("anchor goto svg");
+        fs::write(
+            root.join("components/sidebar.html"),
+            "<html><body>{children}</body></html>",
+        )
+        .expect("sidebar");
+        fs::write(
+            root.join("components/sidebar_each.html"),
+            "<html><body>{title}</body></html>",
+        )
+        .expect("sidebar each");
+        fs::write(
+            root.join("components/embed.html"),
+            "<html><body>{content}</body></html>",
+        )
+        .expect("embed");
+        fs::write(
+            root.join("components/embed_title.html"),
+            "<html><body>{title}</body></html>",
+        )
+        .expect("embed title");
+        fs::write(
+            root.join("schemas/main.html"),
+            "<head></head><body><metadata></metadata></body>",
+        )
+        .expect("schema");
+    }
+
+    pub(crate) fn run_schema_pass_reports_missing_metadata_tag_attr() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("test timestamp should be available")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("typsite-schema-pass-{unique}"));
+        let typst = root.join("typst");
+        let html = root.join("html");
+        write_test_config(&root);
+        fs::create_dir_all(&typst).expect("typst dir");
+        fs::create_dir_all(&html).expect("html dir");
+
+        let config = TypsiteConfig::load(&root, &typst, &html).expect("config should load");
+        let proj = ProjOptions::load(&root).expect("project options should load");
+        init_proj_options(proj).expect("project options should initialize");
+        init_compile_options(CompileOptions {
+            watch: false,
+            short_slug: false,
+            pretty_url: true,
+        })
+        .expect("compile options should initialize");
+
+        let slug: crate::compile::registry::Key = std::sync::Arc::from("/article");
+        let metadata = Metadata {
+            contents: MetaContents::new(slug.clone(), HashMap::new(), false),
+            options: MetaOptions {
+                heading_numbering_style: crate::ir::article::sidebar::HeadingNumberingStyle::Bullet,
+                sidebar_type: crate::ir::article::sidebar::SidebarType::All,
+            },
+            node: MetaNode {
+                slug: slug.clone(),
+                parent: None,
+                parents: HashSet::new(),
+                backlinks: HashSet::new(),
+                references: HashSet::new(),
+                children: HashSet::new(),
+            },
+        };
+        let article = Article::new(
+            slug.clone(),
+            std::sync::Arc::from(std::path::Path::new("article.typ")),
+            metadata,
+            config.schemas.get("main").expect("schema should exist"),
+            Vec::new(),
+            Body::new(Vec::new(), Vec::new(), HashMap::new()),
+            Sidebar::new(
+                Vec::new(),
+                HashSet::new(),
+                HashSet::new(),
+                HashMap::new(),
+                HashMap::new(),
+            ),
+            Sidebar::new(
+                Vec::new(),
+                HashSet::new(),
+                HashSet::new(),
+                HashMap::new(),
+                HashMap::new(),
+            ),
+            Vec::new(),
+            Dependency::new(HashMap::new()),
+            HashSet::new(),
+            Vec::new(),
+        );
+        let articles = HashMap::from([(slug.clone(), article)]);
+        let global_data = GlobalData::new(
+            &config,
+            &articles,
+            HashMap::<_, OnceLock<_>>::new(),
+            HashMap::from([(slug.clone(), Indexes::All)]),
+            HashMap::from([(slug.clone(), Indexes::All)]),
+        );
+
+        let err = SchemaPass::new(
+            &config,
+            config.schemas.get("main").expect("schema should exist"),
+            articles.get(&slug).expect("article should exist"),
+            "",
+            "",
+            &global_data,
+        )
+        .run()
+        .expect_err("missing metadata get attr should not panic");
+        let err = err.to_string();
+
+        assert!(err.contains("required attr `get`"));
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn schema_pass_reports_missing_metadata_tag_attr() {
+        let _guard = crate::test_lock();
+        run_schema_pass_reports_missing_metadata_tag_attr();
     }
 }

--- a/src/pass/tokenizer.rs
+++ b/src/pass/tokenizer.rs
@@ -248,8 +248,8 @@ fn emit_body_next(
                 "h1" | "h2" | "h3" | "h4" | "h5" | "h6" => {
                     let heading_level = name[1..].parse::<usize>()?;
                     let peek = tokenizer.tokenizer.peek();
-                    if peek.is_some() {
-                        let peek = peek.unwrap().clone()?;
+                    if let Some(peek) = peek {
+                        let peek = peek.clone()?;
                         match peek {
                             Token::StartTag(peek) if html_as_str(&peek.name) == EMBED_KEY => {
                                 let _ = tokenizer.tokenizer.next();
@@ -460,21 +460,27 @@ fn emit_other_start(
                 .map(|v| html_as_str(v).to_string())?;
             let url = url.as_ref();
             let tag = if url.starts_with(SVG_ANCHOR_PREFIX) {
-                let url = url.strip_prefix(SVG_ANCHOR_PREFIX).unwrap();
+                let Some(url) = url.strip_prefix(SVG_ANCHOR_PREFIX) else {
+                    return Err(anyhow!("Missing svg anchor prefix after validation"));
+                };
                 BodyTag::AnchorDef {
                     id: url.to_string(),
                     svg_transform: Some(transform),
                 }
             } else if url.starts_with(SVG_GOTO_PREFIX) {
                 state.link_in_svg = true;
-                let url = url.strip_prefix(SVG_GOTO_PREFIX).unwrap();
+                let Some(url) = url.strip_prefix(SVG_GOTO_PREFIX) else {
+                    return Err(anyhow!("Missing svg goto prefix after validation"));
+                };
                 BodyTag::AnchorGoto {
                     id: url.to_string(),
                     svg_transform: Some(transform),
                 }
             } else if url.starts_with(SVG_FOOTNOTE_REF_PREFIX) {
                 state.link_in_svg = true;
-                let footnote = url.strip_prefix(SVG_FOOTNOTE_REF_PREFIX).unwrap();
+                let Some(footnote) = url.strip_prefix(SVG_FOOTNOTE_REF_PREFIX) else {
+                    return Err(anyhow!("Missing svg footnote prefix after validation"));
+                };
                 BodyTag::Rewrite {
                     tag: "footnote-ref-svg".to_string(),
                     attrs: {
@@ -549,4 +555,34 @@ fn emit_other_end(
         _ => {}
     }
     Ok(Some(Event::Other(Token::EndTag(end_tag))))
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::{BodyTag, Event, EventTokenizer, Tokenizer};
+
+    pub(crate) fn run_tokenizer_parses_svg_anchor_without_strip_prefix_panic() {
+        let html = r##"<body><svg><a href="#anchor:svg-target" transform="translate(1 2)"></a></svg></body>"##;
+        let mut raw = html5gum::Tokenizer::new(html).peekable();
+        let mut tokenizer = Tokenizer::<BodyTag>::new(&mut raw);
+
+        loop {
+            match tokenizer.next() {
+                Some(Ok(Event::Start(BodyTag::AnchorDef { id, svg_transform }))) => {
+                    assert_eq!(id, "svg-target");
+                    assert_eq!(svg_transform.as_deref(), Some("translate(1 2)"));
+                    break;
+                }
+                Some(Ok(Event::Eof)) => panic!("svg anchor should produce an AnchorDef event"),
+                Some(Ok(_)) => {}
+                Some(Err(err)) => panic!("svg anchor should parse without error: {err}"),
+                None => panic!("svg anchor should produce an AnchorDef event"),
+            }
+        }
+    }
+
+    #[test]
+    fn tokenizer_parses_svg_anchor_without_strip_prefix_panic() {
+        run_tokenizer_parses_svg_anchor_without_strip_prefix_panic();
+    }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -7,8 +7,11 @@ pub mod path;
 pub mod str;
 
 pub fn pos_slug(pos: &[usize], slug: &str) -> String {
+    let slug = slug
+        .strip_prefix('/')
+        .expect("internal invariant: article slugs always start with '/'");
     if pos.is_empty() {
-        return slug[1..].to_string();
+        return slug.to_string();
     }
     let pos = pos
         .iter()
@@ -16,7 +19,7 @@ pub fn pos_slug(pos: &[usize], slug: &str) -> String {
         .collect::<Vec<_>>()
         .join(".");
     // no "/"
-    format!("{}-{}", &slug[1..], pos)
+    format!("{}-{}", slug, pos)
 }
 
 pub fn pos_base_on(base: Option<&Pos>, pos: Option<&Pos>) -> Pos {
@@ -29,5 +32,30 @@ pub fn pos_base_on(base: Option<&Pos>, pos: Option<&Pos>) -> Pos {
             result
         }
         None => pos.cloned().unwrap_or_default(),
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+
+    pub(crate) fn run_pos_slug_rejects_missing_leading_slash() {
+        let panic = std::panic::catch_unwind(|| pos_slug(&[], "missing-slash"))
+            .expect_err("missing leading slash should violate the invariant");
+        let message = panic
+            .downcast_ref::<String>()
+            .map(String::as_str)
+            .or_else(|| panic.downcast_ref::<&'static str>().copied())
+            .expect("panic payload should be a string message");
+
+        assert_eq!(
+            message,
+            "internal invariant: article slugs always start with '/'"
+        );
+    }
+
+    #[test]
+    fn pos_slug_rejects_missing_leading_slash() {
+        run_pos_slug_rejects_missing_leading_slash();
     }
 }

--- a/src/util/error.rs
+++ b/src/util/error.rs
@@ -32,7 +32,11 @@ pub fn log_err<T, E: std::fmt::Debug>(result: anyhow::Result<T, E>) {
     }
 }
 
-pub fn padding_error(error: &anyhow::Error, padding:&str) -> String{
-    error.to_string().lines().map(|it| format!("{padding}{it}")).collect::<Vec<String>>().join("\n")
+pub fn padding_error(error: &anyhow::Error, padding: &str) -> String {
+    error
+        .to_string()
+        .lines()
+        .map(|it| format!("{padding}{it}"))
+        .collect::<Vec<String>>()
+        .join("\n")
 }
-

--- a/src/util/fs.rs
+++ b/src/util/fs.rs
@@ -1,5 +1,5 @@
 use crate::util::error::TypsiteError;
-use anyhow::{Context, anyhow};
+use anyhow::{anyhow, Context};
 use std::fs;
 use std::path::Path;
 
@@ -149,8 +149,12 @@ fn copy_dir_recursive(from: &Path, to: &Path) -> anyhow::Result<()> {
 #[macro_export]
 macro_rules! walk_glob {
     ($($arg:tt)*) => {
-        glob(&format!($($arg)*))
-            .expect("Invalid pattern")
-            .filter_map(Result::ok)
+        {
+            let pattern = format!($($arg)*);
+            let paths = glob(&pattern)
+                .expect(&format!("glob patterns should be valid internal invariants: {pattern}"));
+            Box::new(paths.filter_map(std::result::Result::ok))
+                as Box<dyn Iterator<Item = std::path::PathBuf> + Send>
+        }
     }
 }

--- a/src/util/html.rs
+++ b/src/util/html.rs
@@ -1,7 +1,7 @@
 use crate::pass::tokenizer::PeekableTokenizer;
 use crate::util::error::TypsiteError;
 use crate::util::str::ElemTokenizerTrait;
-use crate::util::str::{Elem, ElemTokenizer, ac_replace};
+use crate::util::str::{ac_replace, Elem, ElemTokenizer};
 use anyhow::Context;
 use anyhow::Result;
 use anyhow::*;
@@ -15,7 +15,7 @@ use std::fmt;
 use std::fmt::Display;
 use std::fmt::Write;
 use std::fs::File;
-use std::io::{BufReader, read_to_string};
+use std::io::{read_to_string, BufReader};
 use std::path::Path;
 use std::result::Result::Ok;
 
@@ -132,7 +132,7 @@ impl<'ce> Deserialize<'ce> for Attributes {
     }
 }
 
-pub fn from_css_style(str: &str) -> Result<BTreeMap<HtmlString,HtmlString>> {
+pub fn from_css_style(str: &str) -> Result<BTreeMap<HtmlString, HtmlString>> {
     let mut attrs = BTreeMap::new();
     for decl in str.split(';') {
         let decl = decl.trim();
@@ -584,7 +584,7 @@ mod tests {
                     HtmlString::from("0".as_bytes().to_vec()),
                 ),
             ]
-            .into_iter()
+            .into_iter(),
         );
         // Should serialize to a single CSS string
         assert_eq!(
@@ -609,13 +609,16 @@ mod tests {
                     HtmlString::from("0".as_bytes().to_vec()),
                 ),
             ]
-            .into_iter()
+            .into_iter(),
         );
         let serialized = to_css_style(&attrs);
-        assert_eq!(serialized, to_css_style(&from_css_style(&serialized).unwrap()));
+        assert_eq!(
+            serialized,
+            to_css_style(&from_css_style(&serialized).unwrap())
+        );
 
         let raw = "color: red; font-size: 16px; margin: 0;";
-        let de2  = from_css_style(raw).unwrap();
+        let de2 = from_css_style(raw).unwrap();
         assert_eq!(de2, attrs);
     }
 }

--- a/src/util/path.rs
+++ b/src/util/path.rs
@@ -15,7 +15,7 @@ pub fn format_path(path: PathBuf) -> PathBuf {
         .unwrap_or(path)
 }
 
-pub fn verify_if_relative_path<P:AsRef<Path>>(cwd: &Path, path: P) -> Result<PathBuf> {
+pub fn verify_if_relative_path<P: AsRef<Path>>(cwd: &Path, path: P) -> Result<PathBuf> {
     let path = path.as_ref();
     if path.starts_with("/") {
         
@@ -31,9 +31,7 @@ pub fn relative_path(base: &Path, path: &Path) -> Result<PathBuf> {
     path.strip_prefix(base)
         .map(|p| p.to_path_buf())
         .map_err(TypsiteError::PathConversion)
-        .with_context(|| format!(
-            "Failed to convert path {path:?} to relative path of {base:?}"
-        ))
+        .with_context(|| format!("Failed to convert path {path:?} to relative path of {base:?}"))
 }
 
 pub fn dir_name(path: &Path) -> Option<&str> {

--- a/src/util/str.rs
+++ b/src/util/str.rs
@@ -3,15 +3,21 @@ use std::iter::Peekable;
 use std::mem;
 use std::str::Chars;
 
-fn ac_replacement(patterns: Vec<&str>) -> AhoCorasick {
+fn ac_replacement(patterns: &[&str]) -> Option<AhoCorasick> {
+    if patterns.is_empty() {
+        return None;
+    }
+
     AhoCorasick::builder()
         .match_kind(MatchKind::LeftmostLongest)
         .build(patterns)
-        .unwrap()
+        .ok()
 }
 
 pub fn ac_replace_map(text: &str, (patterns, values): (Vec<&str>, Vec<&str>)) -> String {
-    ac_replacement(patterns).replace_all(text, &values)
+    ac_replacement(&patterns)
+        .map(|matcher| matcher.replace_all(text, &values))
+        .unwrap_or_else(|| text.to_string())
 }
 
 pub fn ac_replace(text: &str, replacements: &[(&str, &str)]) -> String {
@@ -54,7 +60,7 @@ pub enum SidebarElem {
     Anchor,
     Title,
     HeadingNumbering,
-    ShowChildren
+    ShowChildren,
 }
 
 impl Elem for SidebarElem {
@@ -138,7 +144,13 @@ impl<E: Elem> ElemTokenizerTrait<E> for ElemTokenizer<'_> {
                     let elem = self.parse_braced_content();
                     return Some(elem);
                 }
-                Some(_) => self.buffer.push(self.chars.next().unwrap()),
+                Some(_) => {
+                    if let Some(next) = self.chars.next() {
+                        self.buffer.push(next);
+                    } else {
+                        break;
+                    }
+                }
                 None => break,
             }
         }
@@ -156,7 +168,7 @@ impl<E: Elem> ElemTokenizerTrait<E> for ElemTokenizer<'_> {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
 
     #[test]
@@ -222,5 +234,14 @@ mod tests {
 
         let only_braces = ElemTokenizer::from::<SidebarElem>("{{}}").collect();
         assert_eq!(only_braces, vec![SidebarElem::Plain("{{}}".into())]);
+    }
+
+    pub(crate) fn run_ac_replacement_handles_empty_patterns_without_unwrap() {
+        assert_eq!(ac_replace("unchanged", &[]), "unchanged");
+    }
+
+    #[test]
+    fn ac_replacement_handles_empty_patterns_without_unwrap() {
+        run_ac_replacement_handles_empty_patterns_without_unwrap();
     }
 }


### PR DESCRIPTION
## Summary
- replace runtime panic!, unwrap, unchecked indexing/slicing, and similar crash-prone paths across parsing, rewrite, pending, compiler, watch, config, and article/metadata assembly with structured errors or explicit documented invariants
- restore and wire exact-name regression coverage for the panic-hardening scenarios so targeted cargo test <name> -- --exact checks work again
- tighten a few late follow-up behaviors, including bounded output cleanup and escaped fallback code highlighting
## Verification
- direnv exec . cargo test --workspace
- direnv exec . cargo clippy --workspace --all-targets
- direnv exec . cargo build